### PR TITLE
Fix double evaluation in **= and //= augmented assignments

### DIFF
--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -308,17 +308,28 @@ class VariablesMixin(TranslatorBase):
     def _capture_target(self, node: ast.AST) -> tuple[str, list[str]]:
         """
         Prepares a target for AugAssign by capturing its components.
+        Recurses on L-value bases (Attribute, Subscript) to preserve reference path.
         Returns (new_target_string, setup_statements).
         """
         if isinstance(node, ast.Name):
             return self.visit(node), []
 
         elif isinstance(node, ast.Attribute):
-            base_expr, base_setup = self._capture_value(node.value)
+            # Recurse on base if it's an L-value container (Name, Attribute, Subscript)
+            # Otherwise capture value (Call, etc.)
+            if isinstance(node.value, (ast.Name, ast.Attribute, ast.Subscript)):
+                base_expr, base_setup = self._capture_target(node.value)
+            else:
+                base_expr, base_setup = self._capture_value(node.value)
+
             return f"{base_expr}.{node.attr}", base_setup
 
         elif isinstance(node, ast.Subscript):
-            base_expr, base_setup = self._capture_value(node.value)
+            # Recurse on base if it's an L-value container
+            if isinstance(node.value, (ast.Name, ast.Attribute, ast.Subscript)):
+                base_expr, base_setup = self._capture_target(node.value)
+            else:
+                base_expr, base_setup = self._capture_value(node.value)
 
             idx_node = node.slice
             # Handle Py < 3.9 ast.Index
@@ -342,7 +353,11 @@ class VariablesMixin(TranslatorBase):
 
             if isinstance(node.op, ast.Pow):
                 self.emitter.add_import("math")
-                self.output.append(f"{self._indent()}{new_target} = math.pow({new_target}, {value})")
+                target_type = self._guess_type(node.target) if hasattr(self, '_guess_type') else "unknown"
+                if target_type == "int":
+                     self.output.append(f"{self._indent()}{new_target} = int(math.pow({new_target}, {value}))")
+                else:
+                     self.output.append(f"{self._indent()}{new_target} = math.pow({new_target}, {value})")
             elif isinstance(node.op, ast.FloorDiv):
                 # //= -> floor division
                 # If types are int, use /

--- a/py2v_transpiler/tests/translator/test_aug_assign.py
+++ b/py2v_transpiler/tests/translator/test_aug_assign.py
@@ -1,4 +1,5 @@
-from typing import List
+import ast
+from typing import List, cast
 from py2v_transpiler.core.translator import VNodeVisitor
 from py2v_transpiler.core.analyzer import TypeInference
 from py2v_transpiler.core.parser import PyASTParser
@@ -8,7 +9,8 @@ def transpile(source: str) -> str:
     tree = parser.parse(source)
     analyzer = TypeInference()
     translator = VNodeVisitor(analyzer)
-    return translator.visit_Module(tree)
+    # Ensure tree is treated as ast.Module for MyPy
+    return translator.visit_Module(cast(ast.Module, tree))
 
 def test_pow_assign_simple():
     source = """
@@ -16,7 +18,8 @@ x = 2
 x **= 3
 """
     v_code = transpile(source)
-    assert "x = math.pow(x, 3)" in v_code
+    # x is int, so we expect cast
+    assert "x = int(math.pow(x, 3))" in v_code
     assert "import math" in v_code
 
 def test_pow_assign_complex_subscript():
@@ -69,18 +72,60 @@ arr = [[1, 2], [3, 4]]
 arr[f()][g()] **= 2
 """
     v_code = transpile(source)
-    # Outer target: arr[f()][g()]
-    # Base: arr[f()] -> captured to tmp1 := arr[f()]
-    # Index: g() -> captured to tmp2 := g()
-    # Result: tmp1[tmp2] = ...
 
-    print(v_code)
+    # Check that f() and g() are captured in assignments
     assert "_aug_tmp_" in v_code
-    # We check that f() and g() appear in assignments
-    assert ":= f()" in v_code or "arr[f()]" in v_code
-    # Actually if arr[f()] is visited, it emits arr[f()].
-    # If captured, it puts it in assignment.
-    # Because _capture_value calls visit(arr[f()]), which emits string "arr[f()]"
-    # Then creates "tmp := arr[f()]".
-    assert ":= arr[f()]" in v_code
+    # Should contain assignments for f() and g() calls
+    assert ":= f()" in v_code
     assert ":= g()" in v_code
+    # Target should be arr[_aug_tmp_1][_aug_tmp_2] approximately
+    # Since _capture_target recurses, arr[f()] is base.
+    # Base _capture_target(arr[f()]) -> base is arr (Name)
+    #   Subscript arr[f()]. Base=arr. Index=f().
+    #   f() -> captured: tmp_f := f()
+    #   returns arr[tmp_f]
+    # Then outer Subscript: base=arr[tmp_f], index=g()
+    #   g() -> captured: tmp_g := g()
+    #   returns arr[tmp_f][tmp_g]
+    # So NO `tmp := arr[f()]`. The path is preserved.
+
+    assert "arr[" in v_code and "][" in v_code
+
+def test_pow_assign_nested_attribute():
+    source = """
+class A:
+    x = 10
+def f(): return A()
+
+# f() returns object (Call). Base is Call.
+# _capture_target(f().x) -> base is f() (Call)
+# Since base is Call (not L-value container like Name/Attr/Subscript), it uses _capture_value.
+# tmp := f()
+# tmp.x = ...
+f().x **= 2
+"""
+    v_code = transpile(source)
+    assert ":= f()" in v_code
+    assert ".x =" in v_code
+
+def test_pow_assign_struct_field():
+    source = """
+class Pt:
+    x = 0
+arr = [Pt()]
+# arr[0].x **= 2
+# _capture_target(arr[0].x)
+# Base arr[0] (Subscript). Recurse.
+# Base arr (Name). Recurse -> "arr".
+# Index 0 (Constant). Recurse -> "0".
+# Returns arr[0].x
+# No temp vars needed for static indices.
+arr[0].x **= 2
+"""
+    v_code = transpile(source)
+    # Should NOT contain temp vars for arr or 0
+    # But wait, unique_id_counter increases globally.
+    # We check if structure is preserved: arr[0].x = ...
+    assert "arr[0].x =" in v_code
+    # And check for int cast (x is int)
+    assert "int(math.pow" in v_code


### PR DESCRIPTION
Fixes issue where augmented assignments `**=` and `//=` caused double evaluation of target expressions. Implements decomposition of complex targets into temporary variables.

---
*PR created automatically by Jules for task [17110176498769245442](https://jules.google.com/task/17110176498769245442) started by @yaskhan*