### PR TITLE
feat: integrate mypy plugin for type extraction

### DIFF
--- a/py2v_transpiler/core/analyzer.py
+++ b/py2v_transpiler/core/analyzer.py
@@ -64,7 +64,51 @@ class TypeInference(ast.NodeVisitor):
         if not mypy_api_module:
             return ("Mypy not installed.", "", 1)
 
-        result, error, exit_code = mypy_api_module.run([path])
+        import tempfile
+        import os
+        import json
+
+        # Create a temporary config file to load the plugin
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write("[mypy]\nplugins = py2v_transpiler.core.mypy_plugin\n")
+            config_path = f.name
+
+        # Store original PYTHONPATH to restore it later
+        original_pythonpath = os.environ.get("PYTHONPATH")
+
+        try:
+            # Set PYTHONPATH so mypy can find the plugin
+            if original_pythonpath is not None:
+                os.environ["PYTHONPATH"] = f".:{original_pythonpath}"
+            else:
+                os.environ["PYTHONPATH"] = "."
+
+            result, error, exit_code = mypy_api_module.run([path, '--config-file', config_path])
+
+            # Read the generated types mapping
+            if os.path.exists("types_for_vlang.json"):
+                try:
+                    with open("types_for_vlang.json", "r") as json_file:
+                        collected_types = json.load(json_file)
+
+                    for fullname, types in collected_types.items():
+                        for location, typ in types.items():
+                            v_type = map_python_type_to_v(typ)
+                            # Extract the variable or function name from fullname if possible
+                            # For now, we will just store it by location as well, or we can use it during transpilation
+                            # but keeping it in self.type_map via a generic key might be tricky.
+                            # We map it by line:column string for potential later use.
+                            self.type_map[f"{fullname}@{location}"] = v_type
+                finally:
+                    os.remove("types_for_vlang.json")
+        finally:
+            if original_pythonpath is not None:
+                os.environ["PYTHONPATH"] = original_pythonpath
+            elif "PYTHONPATH" in os.environ:
+                del os.environ["PYTHONPATH"]
+
+            os.remove(config_path)
+
         return result, error, exit_code
 
     def resolve_type(self, node: ast.AST) -> str:

--- a/py2v_transpiler/core/mypy_plugin.py
+++ b/py2v_transpiler/core/mypy_plugin.py
@@ -1,0 +1,38 @@
+from mypy.plugin import Plugin
+from typing import Any
+import json
+from collections import defaultdict
+
+class VlangPlugin(Plugin):
+    """Mypy plugin for py2v_transpiler to extract type information."""
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.collected_types = defaultdict(dict)
+
+    def get_function_hook(self, fullname: str):
+        def hook(ctx):
+            if hasattr(ctx.context, 'line'):
+                key = f"{ctx.context.line}:{ctx.context.column}"
+                self.collected_types[fullname][key] = str(ctx.default_return_type)
+            return ctx.default_return_type
+        return hook
+
+    def get_method_hook(self, fullname: str):
+        def hook(ctx):
+            if hasattr(ctx.context, 'line'):
+                key = f"{ctx.context.line}:{ctx.context.column}"
+                self.collected_types[fullname][key] = str(ctx.default_return_type)
+            return ctx.default_return_type
+        return hook
+
+    def report_config_data(self, ctx: Any) -> Any:
+        try:
+            with open("types_for_vlang.json", "w") as f:
+                json.dump(dict(self.collected_types), f, indent=2)
+        except Exception:
+            pass
+        return self.collected_types
+
+def plugin(version: str):
+    return VlangPlugin

--- a/py2v_transpiler/tests/test_analyzer.py
+++ b/py2v_transpiler/tests/test_analyzer.py
@@ -60,7 +60,10 @@ def test_run_mypy(mock_mypy):
     assert stdout == "Success"
     assert stderr == ""
     assert code == 0
-    mock_mypy.run.assert_called_with(["test.py"])
+
+    args = mock_mypy.run.call_args[0][0]
+    assert args[0] == "test.py"
+    assert args[1] == "--config-file"
 
 def test_run_mypy_no_module():
     # To test the ImportError case, we'd need to manipulate sys.modules or use a separate process.


### PR DESCRIPTION
This submission introduces a Mypy plugin to extract accurate inferred types during transpilation. The analyzer invokes mypy dynamically using a custom temporary configuration file, runs the mypy API, and parses the extracted JSON mapping line numbers to return types. This mapping allows Py2V to map more nuanced object structures and handle complex type logic moving forward. The `PYTHONPATH` context is securely sandboxed so mypy can load the plugin without modifying global system states permanently.

---
*PR created automatically by Jules for task [12393182743007251231](https://jules.google.com/task/12393182743007251231) started by @yaskhan*