### PR TITLE
feat: Compile-Time Evaluation of `typing.assert_type`

### DIFF
--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -1,6 +1,7 @@
 import ast
 from typing import List, Optional
 from .base import TranslatorBase
+from py2v_transpiler.models.v_types import map_python_type_to_v
 
 class ExpressionsMixin(TranslatorBase):
     def visit_Expr(self, node: ast.Expr) -> None:
@@ -362,6 +363,29 @@ class ExpressionsMixin(TranslatorBase):
                 if types.startswith("[") and types.endswith("]"):
                      return f"/* isinstance({obj}, {types}) - multi-type check not supported */ false"
                 return f"{obj} is {types}"
+
+        elif func_name_str == "assert_type":
+            if len(args) >= 2:
+                # Compile-time evaluation of assert_type
+                # args[0] is the expression, args[1] is the type
+                # We need the actual AST node of the type to map it correctly
+                expr_node = node.args[0]
+                type_node = node.args[1]
+
+                expr_type = self._guess_type(expr_node)
+
+                try:
+                    type_str = ast.unparse(type_node)
+                    expected_type = map_python_type_to_v(type_str)
+                except Exception:
+                    # Fallback if unparse fails
+                    expected_type = str(self.visit(type_node))
+
+                if expr_type == expected_type:
+                    return f"// assert_type({args[0]}, {expected_type}) passed statically"
+                else:
+                    return f"$compile_error('assert_type failed: expected {expected_type} but got {expr_type}')"
+            return "// assert_type requires 2 arguments"
 
         elif func_name_str == "input":
             self.emitter.add_import("os")

--- a/py2v_transpiler/tests/translator/test_assert_type.py
+++ b/py2v_transpiler/tests/translator/test_assert_type.py
@@ -1,0 +1,41 @@
+import pytest
+import ast
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def test_assert_type_pass():
+    code = """
+from typing import assert_type
+
+def test_fn():
+    x = 10
+    assert_type(x, int)
+    """
+    tree = ast.parse(code)
+
+    analyzer = TypeInference()
+    analyzer.visit(tree)
+
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+
+    assert "// assert_type(x, int) passed statically" in v_code
+    assert "$compile_error" not in v_code
+
+def test_assert_type_fail():
+    code = """
+from typing import assert_type
+
+def test_fn():
+    x = 10
+    assert_type(x, float)
+    """
+    tree = ast.parse(code)
+
+    analyzer = TypeInference()
+    analyzer.visit(tree)
+
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+
+    assert "$compile_error('assert_type failed: expected f64 but got int')" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -334,7 +334,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
 - [ ] **Loop Unrolling for Static `tuple` Lengths**
   - *Context:* Mypy can infer exact lengths and types of tuples (e.g., `tuple[int, str, float]`).
   - *V Translation:* When a `for` loop iterates over such a definitively typed static tuple, use the mypy data to unroll the loop during V transpilation, emitting sequential statically typed assignments rather than a dynamic V `for` loop over an `[]Any` array.
-- [ ] **Compile-Time Evaluation of `typing.assert_type`**
+- [x] **Compile-Time Evaluation of `typing.assert_type`**
   - *Context:* Python developers use `assert_type()` to verify mypy's understanding.
   - *V Translation:* Provide a dedicated AST node handler for `assert_type`. Verify that the transpiler's internal type mapping agrees with the mypy plugin's provided type; if it matches, strip the assertion entirely from the V code (zero runtime overhead).
 - [ ] **Exhaustiveness Checking (`typing.assert_never`)**


### PR DESCRIPTION
Implemented compile-time evaluation for `typing.assert_type` as per `todo2.md` tasks. The evaluation checks if the inferred V type matches the expected V type mapped from the Python type annotation. If they match, a comment is emitted ensuring zero runtime overhead. Otherwise, `$compile_error()` is emitted to halt V compilation, mimicking strict static type checking behavior. Tests were added to ensure both code paths work effectively.

---
*PR created automatically by Jules for task [1139658448921291590](https://jules.google.com/task/1139658448921291590) started by @yaskhan*