### PR TITLE
Feat: Implement type-aware list comprehension pre-allocation

### DIFF
--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -705,9 +705,52 @@ class ExpressionsMixin(TranslatorBase):
             self.output.append(f"{self._indent()}// List comprehension expression not supported inline yet")
             return
 
-        self.output.append(f"{self._indent()}mut {target_var} := []int{{}}")
-
         gen = node.generators[0] # Handle first generator
+
+        # Determine capacity for pre-allocation
+        cap_str = ""
+        if not gen.ifs:
+            # Only if there are no filtering conditions
+            if isinstance(gen.iter, (ast.List, ast.Tuple)):
+                cap_str = f"cap: {len(gen.iter.elts)}"
+            elif isinstance(gen.iter, ast.Call) and isinstance(gen.iter.func, ast.Name) and gen.iter.func.id == "range":
+                range_args = gen.iter.args
+                # Check if all arguments are constants
+                all_const = all(
+                    isinstance(arg, ast.Constant) and isinstance(arg.value, int) or
+                    (isinstance(arg, ast.UnaryOp) and isinstance(arg.op, ast.USub) and isinstance(arg.operand, ast.Constant) and isinstance(arg.operand.value, int))
+                    for arg in range_args
+                )
+                if all_const:
+                    def get_int_val(arg):
+                        if isinstance(arg, ast.UnaryOp):
+                            return -arg.operand.value
+                        return arg.value
+
+                    if len(range_args) == 1:
+                        stop = get_int_val(range_args[0])
+                        length = max(0, stop)
+                        cap_str = f"cap: {length}"
+                    elif len(range_args) == 2:
+                        start = get_int_val(range_args[0])
+                        stop = get_int_val(range_args[1])
+                        length = max(0, stop - start)
+                        cap_str = f"cap: {length}"
+                    elif len(range_args) == 3:
+                        start = get_int_val(range_args[0])
+                        stop = get_int_val(range_args[1])
+                        step = get_int_val(range_args[2])
+                        if step != 0:
+                            if step > 0:
+                                length = max(0, (stop - start + step - 1) // step)
+                            else:
+                                length = max(0, (start - stop - step - 1) // (-step))
+                            cap_str = f"cap: {length}"
+
+        if cap_str:
+            self.output.append(f"{self._indent()}mut {target_var} := []int{{{cap_str}}}")
+        else:
+            self.output.append(f"{self._indent()}mut {target_var} := []int{{}}")
 
         if getattr(gen, 'is_async', False):
              self.output.append(f"{self._indent()}// TODO: Async comprehension - Verify iterator semantics")

--- a/py2v_transpiler/tests/translator/test_collections.py
+++ b/py2v_transpiler/tests/translator/test_collections.py
@@ -14,7 +14,8 @@ def test_translator_list_comp():
     analyzer.analyze(tree)
     result = translator.visit_Module(tree)
 
-    assert "mut x := []int{}" in result
+    assert "mut x := []int{cap: 10}" in result
+    # x = [i for i in range(10) if i > 5] has ifs so no cap
     assert "for i in 0..10 {" in result
     assert "x << i" in result
 
@@ -29,6 +30,7 @@ def test_translator_list_comp_filter():
     result = translator.visit_Module(tree)
 
     assert "mut x := []int{}" in result
+    # x = [i for i in range(10) if i > 5] has ifs so no cap
     assert "for i in 0..10 {" in result
     assert "if i > 5 {" in result
     assert "x << i" in result

--- a/py2v_transpiler/tests/translator/test_gen_exp.py
+++ b/py2v_transpiler/tests/translator/test_gen_exp.py
@@ -14,7 +14,8 @@ def test_gen_exp_assignment():
 g = (x for x in range(5))
 """
     v_code = transpile(code)
-    assert "mut g := []int{}" in v_code
+    assert "mut g := []int{cap: 5}" in v_code
+    # zip iter is not simple prealloc
     assert "for x in 0..5" in v_code
     assert "g << x" in v_code
 
@@ -32,5 +33,6 @@ g = (x + y for x, y in zip([1], [2]))
 """
     v_code = transpile(code)
     assert "mut g := []int{}" in v_code
+    # zip iter is not simple prealloc
     assert "_zip_it1_" in v_code
     assert "g << x + y" in v_code

--- a/py2v_transpiler/tests/translator/test_list_comp_prealloc.py
+++ b/py2v_transpiler/tests/translator/test_list_comp_prealloc.py
@@ -1,0 +1,101 @@
+import pytest
+from py2v_transpiler.core.translator.expressions import ExpressionsMixin
+from py2v_transpiler.core.translator.literals import LiteralsMixin
+from py2v_transpiler.core.translator.base import TranslatorBase
+from py2v_transpiler.core.analyzer import TypeInference
+import ast
+
+class DummyTranslator(ExpressionsMixin, LiteralsMixin, TranslatorBase):
+    def __init__(self):
+        type_inference = TypeInference()
+        super().__init__(type_inference)
+        self.output = []
+        self._indent_level = 0
+        self.unique_id_counter = 0
+
+    def visit(self, node):
+        if isinstance(node, ast.Name):
+            return node.id
+        elif isinstance(node, ast.Constant):
+            return str(node.value)
+        elif isinstance(node, ast.List):
+            return f"[{', '.join(str(x.value) for x in node.elts)}]"
+        elif isinstance(node, ast.Tuple):
+            return f"[{', '.join(str(x.value) for x in node.elts)}]"
+        elif isinstance(node, ast.Call):
+            args_str = []
+            for x in node.args:
+                if isinstance(x, ast.Constant):
+                    args_str.append(str(x.value))
+                elif isinstance(x, ast.UnaryOp):
+                    args_str.append(f"-{x.operand.value}")
+                else:
+                    args_str.append(x.id)
+            return f"{node.func.id}({', '.join(args_str)})"
+        elif isinstance(node, ast.BinOp):
+            return f"{self.visit(node.left)} {type(node.op).__name__} {self.visit(node.right)}"
+        elif isinstance(node, ast.UnaryOp):
+            if isinstance(node.op, ast.USub):
+                return f"-{node.operand.value}"
+        return super().visit(node)
+
+def test_list_comp_prealloc_range_1_arg():
+    code = "[i for i in range(10)]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 10}" in v_code
+    assert "for i in 0..10 {" in v_code
+
+def test_list_comp_prealloc_range_2_args():
+    code = "[i for i in range(5, 10)]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 5}" in v_code
+    assert "for i in 5..10 {" in v_code
+
+def test_list_comp_prealloc_range_3_args():
+    code = "[i for i in range(1, 10, 2)]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 5}" in v_code
+    assert "for i := 1; i < 10; i += 2 {" in v_code
+
+def test_list_comp_prealloc_range_negative_step():
+    code = "[i for i in range(10, 1, -2)]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 5}" in v_code
+    assert "for i := 10; i > 1; i += -2 {" in v_code
+
+def test_list_comp_prealloc_list_literal():
+    code = "[i for i in [1, 2, 3, 4]]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 4}" in v_code
+
+def test_list_comp_prealloc_tuple_literal():
+    code = "[i for i in (1, 2, 3)]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{cap: 3}" in v_code
+
+def test_list_comp_no_prealloc_with_ifs():
+    code = "[i for i in range(10) if i > 2]"
+    node = ast.parse(code).body[0].value
+    trans = DummyTranslator()
+    trans.visit_ListComp(node, target_var="res")
+    v_code = "\n".join(trans.output)
+    assert "mut res := []int{}" in v_code
+    assert "cap:" not in v_code

--- a/py2v_transpiler/tests/translator/test_range_step.py
+++ b/py2v_transpiler/tests/translator/test_range_step.py
@@ -45,6 +45,6 @@ def test_list_comp_step():
 squares = [x*x for x in range(0, 10, 2)]
 """
     v_code = translate(source)
-    assert "mut squares := []int{}" in v_code
+    assert "mut squares := []int{cap: 5}" in v_code
     assert "for x := 0; x < 10; x += 2 {" in v_code
     assert "squares << x * x" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -340,7 +340,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
 - [ ] **Exhaustiveness Checking (`typing.assert_never`)**
   - *Context:* Used to ensure all branches of an `Enum` or `Union` are handled.
   - *V Translation:* When the AST contains `assert_never()`, use mypy's control-flow reachability data to verify dead code. Emit a compile-time V error (`$compile_error()`) or `panic()` if the transpiler logic detects the code could be reachable despite mypy's assumptions.
-- [ ] **Type-Aware List Comprehension Pre-allocation**
+- [x] **Type-Aware List Comprehension Pre-allocation**
   - *Context:* List comprehensions currently map to dynamic V arrays built via `<<`.
   - *V Translation:* If mypy can infer the exact length of the iterator (e.g., iterating over a static tuple or bounded range), generate an initially empty V array with the `cap:` set to the inferred length to avoid reallocation during the comprehension loop.
 - [ ] **Strict Structural `TypedDict` Mapping**


### PR DESCRIPTION
Implements the "Type-Aware List Comprehension Pre-allocation" task from `todo2.md`. By determining the bounds of `range()` calls or the length of literal tuples/lists at transpile time, the generated V code initializes the destination array with exact capacity (`cap: N`), optimizing memory allocation. Pre-allocation is correctly bypassed if the list comprehension includes conditional filters. Tests have been added to verify behavior for varying arguments to `range` and handling of iterables.

---
*PR created automatically by Jules for task [4144310512052551210](https://jules.google.com/task/4144310512052551210) started by @yaskhan*