### PR TITLE
feat: strict structural `TypedDict` mapping to V structs

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -61,6 +61,7 @@ class ClassesMixin(TranslatorBase):
         is_unittest = False
         is_protocol = False
         is_named_tuple = False
+        is_typed_dict = False
 
         # Handle inheritance (bases)
         is_flag = False
@@ -82,6 +83,8 @@ class ClassesMixin(TranslatorBase):
                      is_protocol = True
                 elif base.id == "NamedTuple":
                      is_named_tuple = True
+                elif base.id == "TypedDict":
+                     is_typed_dict = True
 
             elif isinstance(base, ast.Attribute):
                 # Check for unittest.TestCase
@@ -95,6 +98,8 @@ class ClassesMixin(TranslatorBase):
                      is_protocol = True
                 elif val == "typing.NamedTuple":
                      is_named_tuple = True
+                elif val == "typing.TypedDict" or val == "TypedDict":
+                     is_typed_dict = True
 
             # Handle Generic[T]
             if isinstance(base, ast.Subscript):
@@ -173,7 +178,7 @@ class ClassesMixin(TranslatorBase):
                         if isinstance(stmt.annotation, ast.Name):
                             field_type = stmt.annotation.id
 
-                if is_dataclass:
+                if is_dataclass or is_typed_dict:
                     dataclass_field_order.append(field_name)
                     if stmt.value:
                         default_val = self.visit(stmt.value)
@@ -200,7 +205,7 @@ class ClassesMixin(TranslatorBase):
                                  fields.append(f"    {slot} int") # Default to int
                                  added_fields.add(slot)
 
-        if is_dataclass:
+        if is_dataclass or is_typed_dict:
             if not hasattr(self, 'dataclasses'):
                 self.dataclasses = {}
             self.dataclasses[struct_name] = dataclass_field_order

--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -560,6 +560,13 @@ class ExpressionsMixin(TranslatorBase):
     def visit_Subscript(self, node: ast.Subscript) -> str:
         value = self.visit(node.value)
 
+        val_type = self._guess_type(node.value)
+        # Check if value is a known TypedDict and index is string literal
+        if hasattr(self, 'dataclasses') and val_type in self.dataclasses:
+             # Fast path for TypedDict access: d["a"] -> d.a
+             if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+                  return f"{value}.{node.slice.value}"
+
         # Handle Ellipsis in slice (e.g. a[...])
         if isinstance(node.slice, ast.Constant) and node.slice.value is Ellipsis:
              return f"{value}[/* ... */]"
@@ -579,7 +586,6 @@ class ExpressionsMixin(TranslatorBase):
         # Handle Ellipsis directly if node.slice is Ellipsis node (not Constant, unlikely in recent python ast but possible)
         # In 3.12, it is usually Constant(value=Ellipsis)
 
-        val_type = self._guess_type(node.value)
         # Fast path: Native V indexing if type is known or fallback 'int' (assumed native array in tests).
         # We only use dynamic fallback if type is explicitly 'Any'
         is_native = True

--- a/py2v_transpiler/core/translator/literals.py
+++ b/py2v_transpiler/core/translator/literals.py
@@ -92,6 +92,20 @@ class LiteralsMixin(TranslatorBase):
         return f"[{', '.join(elements)}]"
 
     def visit_Dict(self, node: ast.Dict) -> str:
+        # Check if the dictionary is being used as a TypedDict
+        v_type = getattr(self, "_guess_type", lambda x: "unknown")(node)
+        if hasattr(self, 'dataclasses') and v_type in self.dataclasses:
+            pairs = []
+            for k, v in zip(node.keys, node.values):
+                if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                    key_str = k.value
+                    val_str = self.visit(v)
+                    pairs.append(f"{key_str}: {val_str}")
+                else:
+                    # Fallback if key is not a string literal? Shouldn't happen in typed dicts usually.
+                    pass
+            return f"{v_type}{{{', '.join(pairs)}}}"
+
         # Check for None keys (unpacking)
         has_unpacking = any(k is None for k in node.keys)
         if has_unpacking:

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -117,6 +117,16 @@ class VariablesMixin(TranslatorBase):
             else:
                  lhs = f"{obj_name}.{target.attr}"
         elif isinstance(target, ast.Subscript):
+            # dict["key"] = value (TypedDict)
+            obj_type = getattr(self, "_guess_type", lambda x: "unknown")(target.value)
+            if hasattr(self, 'dataclasses') and obj_type in self.dataclasses:
+                list_obj = self.visit(target.value)
+                if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
+                    lhs = f"{list_obj}.{target.slice.value}"
+                    rhs = self.visit(node.value)
+                    self.output.append(f"{self._indent()}{lhs} = {rhs}")
+                    return
+
             # list[index] = value
             # Check for slice assignment: l[1:3] = [4, 5]
             if isinstance(target.slice, ast.Slice):
@@ -249,6 +259,17 @@ class VariablesMixin(TranslatorBase):
                 for elt in value_node.elts:
                     val = self.visit(elt)
                     self.output.append(f"{self._indent()}{lhs} << {val}")
+            elif hasattr(self, 'dataclasses') and v_type in self.dataclasses and isinstance(node.value, ast.Dict):
+                # TypedDict assignment
+                pairs = []
+                for k, v in zip(node.value.keys, node.value.values):
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        key_str = k.value
+                        val_str = self.visit(v)
+                        pairs.append(f"{key_str}: {val_str}")
+
+                rhs = f"{v_type}{{{', '.join(pairs)}}}"
+                self.output.append(f"{self._indent()}{lhs} := {rhs}")
             else:
                 rhs = self.visit(node.value)
                 self.output.append(f"{self._indent()}{lhs} := {rhs}")
@@ -465,6 +486,17 @@ class VariablesMixin(TranslatorBase):
                 for elt in value_node.elts:
                     val = self.visit(elt)
                     self.output.append(f"{self._indent()}{target} << {val}")
+            elif hasattr(self, 'dataclasses') and v_type in self.dataclasses and isinstance(node.value, ast.Dict):
+                # TypedDict assignment
+                pairs = []
+                for k, v in zip(node.value.keys, node.value.values):
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        key_str = k.value
+                        val_str = self.visit(v)
+                        pairs.append(f"{key_str}: {val_str}")
+
+                rhs = f"{v_type}{{{', '.join(pairs)}}}"
+                self.output.append(f"{self._indent()}{target} := {rhs}")
             else:
                 rhs = self.visit(node.value)
                 # We ignore the annotation for now and rely on type inference and V's auto-typing

--- a/py2v_transpiler/tests/translator/test_typed_dict.py
+++ b/py2v_transpiler/tests/translator/test_typed_dict.py
@@ -1,0 +1,114 @@
+import ast
+from py2v_transpiler.core.translator.classes import ClassesMixin
+from py2v_transpiler.core.translator.variables import VariablesMixin
+from py2v_transpiler.core.translator.functions import FunctionsMixin
+from py2v_transpiler.core.translator.expressions import ExpressionsMixin
+from py2v_transpiler.core.translator.literals import LiteralsMixin
+from py2v_transpiler.core.generator import VCodeEmitter
+from py2v_transpiler.core.coroutines import CoroutineHandler
+from unittest.mock import MagicMock
+
+class MockTypeInference:
+    def __init__(self):
+        self.type_map = {}
+        self.location_map = {}
+
+    def resolve_type(self, node):
+        if isinstance(node, ast.Name):
+            return self.type_map.get(node.id, "void")
+        return "void"
+
+class _TestTranslator(ClassesMixin, VariablesMixin, FunctionsMixin, ExpressionsMixin, LiteralsMixin):
+    def __init__(self):
+        self.output = []
+        self.emitter = VCodeEmitter()
+        self.coroutine_handler = CoroutineHandler()
+        self._indent_level = 0
+        self.current_class = None
+        self.current_class_generics = []
+        self.current_class_bases = []
+        self.current_class_is_unittest = False
+        self.imported_modules = {}
+        self.imported_symbols = {}
+        self.renamed_functions = {}
+        self.function_names = set()
+        self.used_builtins = set()
+        self.unique_id_counter = 0
+        self.name_remap = {}
+        self._walrus_assignments = []
+        self._zip_counter = 0
+        self.in_main = False
+        self.single_dispatch_functions = {}
+        self.vexc_depth = 0
+        self.type_inference = MockTypeInference()
+
+        # Mocking
+        self.decorator_processor = MagicMock()
+        self.decorator_processor.analyze.return_value = MagicMock(
+            is_static=False, is_setter=False,
+            cache_wrapper_needed=False, implementation_name=None,
+            injected_start=[], injected_end=[]
+        )
+        self.mapper = MagicMock()
+        self.mapper.get_mapping.return_value = None
+        self.mapper.get_constant_mapping.return_value = None
+        self.dataclasses = {}
+
+    def _indent(self):
+        return "    " * self._indent_level
+
+    def visit(self, node):
+        method = 'visit_' + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        return visitor(node)
+
+    def generic_visit(self, node):
+        if hasattr(node, "body"):
+            for stmt in node.body:
+                self.visit(stmt)
+        return ""
+
+    def _guess_type(self, node):
+        if isinstance(node, ast.Name):
+            return self.type_inference.type_map.get(node.id, "int")
+        return "int"
+
+    def _mangle_name(self, name, class_name):
+        return name
+
+def test_typed_dict():
+    code = """
+from typing import TypedDict
+
+class MyDict(TypedDict):
+    a: int
+    b: str
+
+class MyDict2(TypedDict, total=False):
+    a: int
+    b: str
+
+d: MyDict = {"a": 1, "b": "hello"}
+d["a"] = 2
+d["b"] = "world"
+print(d["a"])
+"""
+    tree = ast.parse(code)
+    translator = _TestTranslator()
+
+    # Simulate mypy inferring type as TypedDict struct
+    translator.type_inference.type_map["d"] = "MyDict"
+
+    translator.visit(tree)
+
+    structs = translator.emitter.structs
+    assert any("struct MyDict {" in s for s in structs)
+
+    v_code = "\n".join(translator.output)
+    print("V_CODE:")
+    print(v_code)
+
+    assert "d := MyDict{a: 1, b: 'hello'}" in v_code
+    assert "d.a = 2" in v_code
+    assert "d.b = 'world'" in v_code
+    assert "d.a" in v_code

--- a/run_test.py
+++ b/run_test.py
@@ -1,0 +1,2 @@
+import subprocess
+print(subprocess.run(["python", "-m", "pytest", "py2v_transpiler/tests/translator/test_typed_dict.py"], capture_output=True).stdout.decode('utf-8'))

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,57 @@
+1. Modify `py2v_transpiler/core/translator/classes.py`
+    - Add logic in `visit_ClassDef` to check if a class inherits from `TypedDict` or `typing.TypedDict`.
+    - Set `is_typed_dict = True` when found.
+    - If `is_typed_dict = True`, register the struct name in `self.dataclasses` just like we do for `@dataclass`. This will allow `visit_Call` and `visit_Dict` (or assignments) to use struct initialization and field access, since `dataclasses` tells the transpiler the exact layout of the struct. We can reuse `dataclasses` dict or create a new `typed_dicts` dict.
+    - Let's create `self.typed_dicts = set()` or reuse `self.dataclasses`. Reusing `self.dataclasses` is probably the easiest because `hasattr(self, 'dataclasses')` and `func_name_str in self.dataclasses` are already used to enable struct initialization.
+
+2. Modify `py2v_transpiler/core/translator/literals.py`
+    - In `visit_Dict`, if we can infer that the dict literal is being assigned to a TypedDict (via `_guess_type` of the target node, but `visit_Dict` doesn't know its target context directly).
+    - Actually, `visit_AnnAssign` and `visit_Assign` are where the target type is known.
+    - In `visit_AnnAssign`, if `v_type` matches a known TypedDict (i.e., it's a struct name), we could transform the dict literal into a struct initialization.
+    - However, `node.value` is visited *before* we can intercept it inside `visit_AnnAssign` usually, or we can check `isinstance(node.value, ast.Dict)` and handle it specially.
+    - Let's look at `visit_AnnAssign` in `variables.py`: it currently does `rhs = self.visit(node.value)` and emits `target := rhs`. If we check if `v_type` is in `self.dataclasses` (or a known TypedDict), we can format it as a struct initializer instead of a `map[string]int`.
+    - Wait, `visit_Dict` translates `{"a": 1}` to `map[string]int{'a': 1}`. We can add a `target_type` parameter to `visit_Dict`? No, AST visitors generally don't take parameters.
+
+    - Better approach: In `visit_AnnAssign` and `visit_Assign`, if RHS is `ast.Dict` and `v_type` is a TypedDict struct, we can bypass `self.visit(node.value)` and manually translate it into a struct initialization.
+    - E.g. `d: MyDict = {"a": 1}` -> `d := MyDict{a: 1}`.
+    - What if it's not a top-level assignment? `foo({"a": 1})` where `foo(d: MyDict)`. It's harder.
+    - If mypy infers the type of the dict literal itself as `MyDict`? Yes, mypy infers it. So `self._guess_type(node)` on the `ast.Dict` node would return `MyDict`!
+    - So in `visit_Dict` in `literals.py`:
+      ```python
+      v_type = self._guess_type(node)
+      if hasattr(self, 'dataclasses') and v_type in self.dataclasses:
+          # Check if it's a TypedDict (we can add a flag or just assume any known struct)
+          # Struct initialization: MyDict{a: 1, b: 2}
+          pairs = []
+          for k, v in zip(node.keys, node.values):
+              if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                  key_str = k.value
+                  val_str = self.visit(v)
+                  pairs.append(f"{key_str}: {val_str}")
+          return f"{v_type}{{{', '.join(pairs)}}}"
+      ```
+
+3. Modify `py2v_transpiler/core/translator/expressions.py`
+    - For `visit_Subscript` (i.e. `d["a"]`), if `value` type is a TypedDict struct (via `self._guess_type(node.value)`), then it should be transpiled to `d.a` instead of `d['a']`.
+    - `visit_Subscript`:
+      ```python
+      val_type = self._guess_type(node.value)
+      if hasattr(self, 'dataclasses') and val_type in self.dataclasses:
+          if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+              return f"{value}.{node.slice.value}"
+      ```
+
+4. Modify `py2v_transpiler/core/translator/variables.py`
+    - For `visit_Assign` and `visit_AnnAssign`, where target is `ast.Subscript` (i.e. `d["a"] = 2`), if `d` is a TypedDict struct, it should be transpiled to `d.a = 2`.
+    - `visit_Assign`:
+      ```python
+      elif isinstance(target, ast.Subscript):
+          list_obj = self.visit(target.value)
+          obj_type = self._guess_type(target.value)
+          if hasattr(self, 'dataclasses') and obj_type in self.dataclasses:
+              if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
+                  lhs = f"{list_obj}.{target.slice.value}"
+                  rhs = self.visit(node.value)
+                  self.output.append(f"{self._indent()}{lhs} = {rhs}")
+                  return
+      ```

--- a/test_typed_dict.py
+++ b/test_typed_dict.py
@@ -1,0 +1,20 @@
+from typing import TypedDict, Any
+
+class Point2D(TypedDict):
+    x: int
+    y: int
+
+class Point3D(TypedDict, total=False):
+    x: int
+    y: int
+    z: int
+
+def foo():
+    p1: Point2D = {"x": 1, "y": 2}
+    p2: Point3D = {"x": 1, "y": 2, "z": 3}
+    p3 = {"a": 1, "b": 2} # untyped fallback
+
+    print(p1["x"])
+    print(p2.get("z", 0))
+
+foo()

--- a/test_typed_dict.v
+++ b/test_typed_dict.v
@@ -1,0 +1,90 @@
+module main
+
+type Any = bool | int | i64 | f64 | string | []u8
+struct Point2D {
+    x int
+    y int
+}
+struct Point3D {
+    x int
+    y int
+    z int
+}
+struct PyGeneratorInput {
+    val Any
+    is_exc bool
+    exc_msg string
+}
+struct PyGenerator[T] {
+mut:
+    out chan ?T
+    in_ chan PyGeneratorInput
+    open bool = true
+}
+
+fn foo() {
+    p1 := map[string]int{'x': 1, 'y': 2}
+    p2 := map[string]int{'x': 1, 'y': 2, 'z': 3}
+    p3 := map[string]int{'a': 1, 'b': 2}
+    println('${p1['x']}')
+    println('${p2.get('z', 0)}')
+}
+fn py_format(val Any, spec string) string {
+    // Dynamic format specifier support is limited.
+    // V does not support runtime format string construction easily.
+    // We fallback to standard string representation.
+    return '${val}'
+}
+fn (mut g PyGenerator[T]) next() ?T {
+    if !g.open { return none }
+    g.in_ <- PyGeneratorInput{val: 0} // Send dummy value
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) send(val Any) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{val: val}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) throw(msg string) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{is_exc: true, exc_msg: msg}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) close() {
+    g.open = false
+    g.in_.close()
+    // g.out will be closed by the generator function loop when it detects in_ closed or panic
+}
+fn py_yield[T](ch_out chan ?T, ch_in chan PyGeneratorInput, val T) Any {
+    ch_out <- val
+    inp := <-ch_in
+    if inp.is_exc {
+        panic(inp.exc_msg)
+    }
+    return inp.val
+}
+fn py_bytes_format(fmt []u8, args Any) []u8 {
+    // Simplistic implementation for b'%s' % b'val'
+    // Converts bytes to string, formats, and converts back.
+    // This is not efficient or correct for non-ASCII bytes but works for simple cases.
+    fmt_str := fmt.bytestr()
+    // TODO: handle args properly. V's string interpolation/formatting expects distinct args.
+    // If args is []u8, treat as string.
+    arg_str := if args is []u8 { args.bytestr() } else { '${args}' }
+
+    // Manual substitution of %s
+    // V does not have sprintf for runtime strings easily available in core without C interop.
+    // Simple replace for %s
+    res := fmt_str.replace('%s', arg_str)
+    return res.bytes()
+}
+
+fn main() {
+    foo()
+}

--- a/test_typed_dict2.py
+++ b/test_typed_dict2.py
@@ -1,0 +1,8 @@
+from typing import TypedDict
+
+class MyDict(TypedDict):
+    a: int
+    b: str
+
+d: MyDict = {"a": 1, "b": "hello"}
+print(d["a"])

--- a/test_typed_dict2.v
+++ b/test_typed_dict2.v
@@ -1,0 +1,79 @@
+module main
+
+type Any = bool | int | i64 | f64 | string | []u8
+struct MyDict {
+    a int
+    b string
+}
+struct PyGeneratorInput {
+    val Any
+    is_exc bool
+    exc_msg string
+}
+struct PyGenerator[T] {
+mut:
+    out chan ?T
+    in_ chan PyGeneratorInput
+    open bool = true
+}
+
+fn py_format(val Any, spec string) string {
+    // Dynamic format specifier support is limited.
+    // V does not support runtime format string construction easily.
+    // We fallback to standard string representation.
+    return '${val}'
+}
+fn (mut g PyGenerator[T]) next() ?T {
+    if !g.open { return none }
+    g.in_ <- PyGeneratorInput{val: 0} // Send dummy value
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) send(val Any) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{val: val}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) throw(msg string) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{is_exc: true, exc_msg: msg}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) close() {
+    g.open = false
+    g.in_.close()
+    // g.out will be closed by the generator function loop when it detects in_ closed or panic
+}
+fn py_yield[T](ch_out chan ?T, ch_in chan PyGeneratorInput, val T) Any {
+    ch_out <- val
+    inp := <-ch_in
+    if inp.is_exc {
+        panic(inp.exc_msg)
+    }
+    return inp.val
+}
+fn py_bytes_format(fmt []u8, args Any) []u8 {
+    // Simplistic implementation for b'%s' % b'val'
+    // Converts bytes to string, formats, and converts back.
+    // This is not efficient or correct for non-ASCII bytes but works for simple cases.
+    fmt_str := fmt.bytestr()
+    // TODO: handle args properly. V's string interpolation/formatting expects distinct args.
+    // If args is []u8, treat as string.
+    arg_str := if args is []u8 { args.bytestr() } else { '${args}' }
+
+    // Manual substitution of %s
+    // V does not have sprintf for runtime strings easily available in core without C interop.
+    // Simple replace for %s
+    res := fmt_str.replace('%s', arg_str)
+    return res.bytes()
+}
+
+fn main() {
+    d := map[string]int{'a': 1, 'b': 'hello'}
+    println('${d['a']}')
+}

--- a/test_typed_dict3.py
+++ b/test_typed_dict3.py
@@ -1,0 +1,8 @@
+from typing import TypedDict
+
+class MyDict(TypedDict):
+    a: int
+    b: str
+
+d: MyDict = {"a": 1, "b": "hello"}
+d["a"] = 2

--- a/test_typed_dict3.v
+++ b/test_typed_dict3.v
@@ -1,0 +1,79 @@
+module main
+
+type Any = bool | int | i64 | f64 | string | []u8
+struct MyDict {
+    a int
+    b string
+}
+struct PyGeneratorInput {
+    val Any
+    is_exc bool
+    exc_msg string
+}
+struct PyGenerator[T] {
+mut:
+    out chan ?T
+    in_ chan PyGeneratorInput
+    open bool = true
+}
+
+fn py_format(val Any, spec string) string {
+    // Dynamic format specifier support is limited.
+    // V does not support runtime format string construction easily.
+    // We fallback to standard string representation.
+    return '${val}'
+}
+fn (mut g PyGenerator[T]) next() ?T {
+    if !g.open { return none }
+    g.in_ <- PyGeneratorInput{val: 0} // Send dummy value
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) send(val Any) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{val: val}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) throw(msg string) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{is_exc: true, exc_msg: msg}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) close() {
+    g.open = false
+    g.in_.close()
+    // g.out will be closed by the generator function loop when it detects in_ closed or panic
+}
+fn py_yield[T](ch_out chan ?T, ch_in chan PyGeneratorInput, val T) Any {
+    ch_out <- val
+    inp := <-ch_in
+    if inp.is_exc {
+        panic(inp.exc_msg)
+    }
+    return inp.val
+}
+fn py_bytes_format(fmt []u8, args Any) []u8 {
+    // Simplistic implementation for b'%s' % b'val'
+    // Converts bytes to string, formats, and converts back.
+    // This is not efficient or correct for non-ASCII bytes but works for simple cases.
+    fmt_str := fmt.bytestr()
+    // TODO: handle args properly. V's string interpolation/formatting expects distinct args.
+    // If args is []u8, treat as string.
+    arg_str := if args is []u8 { args.bytestr() } else { '${args}' }
+
+    // Manual substitution of %s
+    // V does not have sprintf for runtime strings easily available in core without C interop.
+    // Simple replace for %s
+    res := fmt_str.replace('%s', arg_str)
+    return res.bytes()
+}
+
+fn main() {
+    d := map[string]int{'a': 1, 'b': 'hello'}
+    d['a'] := 2
+}

--- a/test_typed_dict4.py
+++ b/test_typed_dict4.py
@@ -1,0 +1,16 @@
+from typing import TypedDict
+
+class MyDict(TypedDict):
+    a: int
+    b: str
+
+class MyDict2(TypedDict, total=False):
+    a: int
+    b: str
+
+def foo():
+    d: MyDict = {"a": 1, "b": "hello"}
+    d["a"] = 2
+    d["b"] = "world"
+
+foo()

--- a/test_typed_dict4.v
+++ b/test_typed_dict4.v
@@ -1,0 +1,87 @@
+module main
+
+type Any = bool | int | i64 | f64 | string | []u8
+struct MyDict {
+    a int
+    b string
+}
+struct MyDict2 {
+    a int
+    b string
+}
+struct PyGeneratorInput {
+    val Any
+    is_exc bool
+    exc_msg string
+}
+struct PyGenerator[T] {
+mut:
+    out chan ?T
+    in_ chan PyGeneratorInput
+    open bool = true
+}
+
+fn foo() {
+    d := MyDict{a: 1, b: 'hello'}
+    d.a = 2
+    d.b = 'world'
+}
+fn py_format(val Any, spec string) string {
+    // Dynamic format specifier support is limited.
+    // V does not support runtime format string construction easily.
+    // We fallback to standard string representation.
+    return '${val}'
+}
+fn (mut g PyGenerator[T]) next() ?T {
+    if !g.open { return none }
+    g.in_ <- PyGeneratorInput{val: 0} // Send dummy value
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) send(val Any) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{val: val}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) throw(msg string) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{is_exc: true, exc_msg: msg}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) close() {
+    g.open = false
+    g.in_.close()
+    // g.out will be closed by the generator function loop when it detects in_ closed or panic
+}
+fn py_yield[T](ch_out chan ?T, ch_in chan PyGeneratorInput, val T) Any {
+    ch_out <- val
+    inp := <-ch_in
+    if inp.is_exc {
+        panic(inp.exc_msg)
+    }
+    return inp.val
+}
+fn py_bytes_format(fmt []u8, args Any) []u8 {
+    // Simplistic implementation for b'%s' % b'val'
+    // Converts bytes to string, formats, and converts back.
+    // This is not efficient or correct for non-ASCII bytes but works for simple cases.
+    fmt_str := fmt.bytestr()
+    // TODO: handle args properly. V's string interpolation/formatting expects distinct args.
+    // If args is []u8, treat as string.
+    arg_str := if args is []u8 { args.bytestr() } else { '${args}' }
+
+    // Manual substitution of %s
+    // V does not have sprintf for runtime strings easily available in core without C interop.
+    // Simple replace for %s
+    res := fmt_str.replace('%s', arg_str)
+    return res.bytes()
+}
+
+fn main() {
+    foo()
+}

--- a/todo2.md
+++ b/todo2.md
@@ -343,7 +343,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
 - [x] **Type-Aware List Comprehension Pre-allocation**
   - *Context:* List comprehensions currently map to dynamic V arrays built via `<<`.
   - *V Translation:* If mypy can infer the exact length of the iterator (e.g., iterating over a static tuple or bounded range), generate an initially empty V array with the `cap:` set to the inferred length to avoid reallocation during the comprehension loop.
-- [ ] **Strict Structural `TypedDict` Mapping**
+- [x] **Strict Structural `TypedDict` Mapping**
   - *Context:* Python dictionaries can be highly dynamic, often falling back to `map[string]Any`.
   - *V Translation:* If mypy explicitly types a dictionary assignment/usage as a specific `TypedDict`, bypass the `map` entirely and emit it as an exact, unboxed V `struct` to ensure zero-overhead field access.
 - [ ] **Generic Type Aliases Mapping (PEP 695)**


### PR DESCRIPTION
When mypy infers a dictionary assignment or usage as a specific TypedDict, the transpiler now bypasses the generic `map[string]Any` fallback and emits an exact, unboxed V `struct`. This allows zero-overhead field access, resolving a task from `todo2.md`.

Changes include:
- `ClassesMixin.visit_ClassDef`: Register `TypedDict` derived classes into `self.dataclasses` to inform the generator.
- `LiteralsMixin.visit_Dict`: Intercept dictionary literals bound to a registered TypedDict and format them as struct initializations (`MyDict{key: val}`).
- `ExpressionsMixin.visit_Subscript`: Translate string-literal key accesses (`d["key"]`) on TypedDicts to direct field accesses (`d.key`).
- `VariablesMixin.visit_Assign` and `visit_AnnAssign`:
  - Translate dictionary target assignment (`d["key"] = val`) to field assignment (`d.key = val`).
  - Translate typed assignments (`d: MyDict = {"key": 1}`) directly into struct initializations.
- `test_typed_dict.py`: Added test suite to ensure accurate TypedDict resolution.

---
*PR created automatically by Jules for task [782983971018727029](https://jules.google.com/task/782983971018727029) started by @yaskhan*