### PR TITLE
Statically Typed `*args` and `**kwargs`

### DIFF
--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -177,25 +177,44 @@ class FunctionsMixin(TranslatorBase):
 
         if node.args.vararg:
             arg_name = node.args.vararg.arg
-            arg_type = "int" # Default
+            arg_type = "Any" # Default
             if node.args.vararg.annotation:
                 try:
                     type_str = ast.unparse(node.args.vararg.annotation)
                     arg_type = map_python_type_to_v(type_str, self_name=struct_name or "Self")
                 except Exception:
                     pass
+            else:
+                inferred_type = self.type_inference.type_map.get(arg_name)
+                if inferred_type:
+                    if inferred_type.startswith("[]"):
+                        arg_type = inferred_type[2:]
+                    elif inferred_type == "Any":
+                        arg_type = "Any"
+
             args_str_list.append(f"{arg_name} ...{arg_type}")
             args_names.append(arg_name)
 
         if node.args.kwarg:
             arg_name = node.args.kwarg.arg
-            arg_type = "map[string]string"
+            arg_type = "Any"
             if node.args.kwarg.annotation:
                 try:
                     type_str = ast.unparse(node.args.kwarg.annotation)
-                    arg_type = map_python_type_to_v(type_str, self_name=struct_name or "Self")
+                    val_type = map_python_type_to_v(type_str, self_name=struct_name or "Self")
+                    arg_type = f"map[string]{val_type}"
                 except Exception:
-                    pass
+                    arg_type = "map[string]Any"
+            else:
+                inferred_type = self.type_inference.type_map.get(arg_name)
+                if inferred_type:
+                    if inferred_type.startswith("map[string]"):
+                        arg_type = inferred_type
+                    elif inferred_type == "Any":
+                        arg_type = "map[string]Any"
+                if arg_type == "Any":
+                    arg_type = "map[string]Any"
+
             args_str_list.append(f"{arg_name} {arg_type}")
             args_names.append(arg_name)
 

--- a/py2v_transpiler/tests/translator/test_kwargs_def.py
+++ b/py2v_transpiler/tests/translator/test_kwargs_def.py
@@ -15,7 +15,7 @@ def f(**kwargs):
     pass
 """
     v_code = transpile(code)
-    assert "fn f(kwargs map[string]string)" in v_code
+    assert "fn f(kwargs map[string]Any)" in v_code
 
 def test_kwargs_def_mixed():
     code = """
@@ -23,4 +23,4 @@ def f(a, **kwargs):
     pass
 """
     v_code = transpile(code)
-    assert "fn f(a int, kwargs map[string]string)" in v_code
+    assert "fn f(a int, kwargs map[string]Any)" in v_code

--- a/py2v_transpiler/tests/translator/test_varargs.py
+++ b/py2v_transpiler/tests/translator/test_varargs.py
@@ -15,7 +15,7 @@ def f(*args):
     pass
 """
     v_code = transpile(code)
-    assert "fn f(args ...int)" in v_code
+    assert "fn f(args ...Any)" in v_code
 
 def test_varargs_mixed():
     code = """
@@ -23,7 +23,7 @@ def f(a, *b):
     pass
 """
     v_code = transpile(code)
-    assert "fn f(a int, b ...int)" in v_code
+    assert "fn f(a int, b ...Any)" in v_code
 
 def test_varargs_with_type_annotation():
     code = """

--- a/py2v_transpiler/tests/translator/test_variadic.py
+++ b/py2v_transpiler/tests/translator/test_variadic.py
@@ -1,0 +1,24 @@
+import unittest
+from py2v_transpiler.main import Transpiler
+
+class TestVariadic(unittest.TestCase):
+    def test_variadic_args(self):
+        code = """
+def homogeneous(*args: int, **kwargs: int):
+    pass
+
+def heterogeneous(*args: 'Any', **kwargs: 'Any'):
+    pass
+
+def unannotated(*args, **kwargs):
+    pass
+"""
+        transpiler = Transpiler()
+        output = transpiler.transpile(code)
+
+        self.assertIn("fn homogeneous(args ...int, kwargs map[string]int) {", output)
+        self.assertIn("fn heterogeneous(args ...Any, kwargs map[string]Any) {", output)
+        self.assertIn("fn unannotated(args ...Any, kwargs map[string]Any) {", output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements statically typed variadic arguments by modifying the V code generation for `*args` and `**kwargs`.
When Python variadic arguments are homogeneous and correctly annotated (e.g., `*args: int`), the transpiler now explicitly maps them to native V arrays (`[]int`) or maps (`map[string]int`). Without explicit type information, the transpiler now properly falls back to `Any` and `map[string]Any`, fixing an issue where they fell back to incorrect primitive types `int` and `map[string]string`.

---
*PR created automatically by Jules for task [4549380703684627074](https://jules.google.com/task/4549380703684627074) started by @yaskhan*