### PR TITLE
feat: Implement exception block type narrowing

### DIFF
--- a/py2v_transpiler/core/translator/control_flow.py
+++ b/py2v_transpiler/core/translator/control_flow.py
@@ -339,7 +339,22 @@ class ControlFlowMixin(TranslatorBase):
 
                  self._indent_level += 1
                  if handler.name:
-                      self.output.append(f"{self._indent()}{handler.name} := {exc_var}")
+                      mapped_type = self.type_inference.type_map.get(handler.name)
+                      if mapped_type and mapped_type not in ("void", "Any"):
+                          self.output.append(f"{self._indent()}{handler.name} := {exc_var} as {mapped_type}")
+                      else:
+                          # Fallback to the AST node's type if mypy didn't track it
+                          fallback_type = None
+                          if handler.type:
+                              if isinstance(handler.type, ast.Name):
+                                  fallback_type = handler.type.id
+                              elif isinstance(handler.type, ast.Attribute):
+                                  fallback_type = handler.type.attr
+
+                          if fallback_type and fallback_type not in ("Exception", "BaseException", "ExceptionGroup"):
+                              self.output.append(f"{self._indent()}{handler.name} := {exc_var} as {fallback_type}")
+                          else:
+                              self.output.append(f"{self._indent()}{handler.name} := {exc_var}")
 
                  for stmt in handler.body:
                       self.visit(stmt)

--- a/py2v_transpiler/tests/translator/test_exceptions_vexc.py
+++ b/py2v_transpiler/tests/translator/test_exceptions_vexc.py
@@ -89,3 +89,52 @@ def test_finally():
     v_code = translator.visit_Module(ast_tree)
 
     assert "defer {" in v_code
+
+def test_exception_type_narrowing():
+    code = """
+class MyError(Exception):
+    def __init__(self, code: int):
+        self.code = code
+
+def test_narrow():
+    try:
+        raise MyError(404)
+    except MyError as e:
+        print(e.code)
+"""
+    parser = PyASTParser()
+    ast_tree = parser.parse(code)
+    analyzer = TypeInference()
+
+    # Simulate mypy plugin providing the type
+    analyzer.type_map['e'] = 'MyError'
+
+    translator = VNodeVisitor(analyzer)
+    analyzer.analyze(ast_tree)
+    v_code = translator.visit_Module(ast_tree)
+
+    # Verify the generated V code contains the correct typecast
+    assert "e := _exc_0 as MyError" in v_code
+    # Verify the code accesses the strongly typed field
+    assert "println('${e.code}')" in v_code
+
+def test_exception_type_narrowing_fallback():
+    code = """
+class CustomException(Exception):
+    pass
+
+def test_fallback():
+    try:
+        pass
+    except CustomException as e:
+        print(e)
+"""
+    parser = PyASTParser()
+    ast_tree = parser.parse(code)
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    analyzer.analyze(ast_tree)
+    v_code = translator.visit_Module(ast_tree)
+
+    # Verify the generated V code falls back to the AST hint
+    assert "e := _exc_0 as CustomException" in v_code


### PR DESCRIPTION
This PR implements the "Exception Block Type Narrowing" feature from `todo2.md`. 

Previously, when converting python `except MyException as e:` blocks, `e` was assigned as a generic `vexc.Exception` struct regardless of the exception caught. The new behavior uses the transpiler's `TypeInference` state (populated via `mypy` plugin) to determine if `e` can be explicitly downcasted to the specific exception's struct in Vlang (e.g. `e := _exc_0 as MyException`). If `mypy` typing fails or is missing, it falls back to parsing the underlying AST `ExceptionHandler` node to try and infer the exception type. This enables Vlang code to access custom fields added to subclassed exceptions without resorting to `Any` typecasting.

Tests are added to `py2v_transpiler/tests/translator/test_exceptions_vexc.py`.

---
*PR created automatically by Jules for task [7349795205231334778](https://jules.google.com/task/7349795205231334778) started by @yaskhan*