### PR TITLE
Fix type casts to `float`

### DIFF
--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -438,6 +438,11 @@ class ExpressionsMixin(TranslatorBase):
                 return f"math.round({args[0]})"
 
 
+        elif func_name_str == "float":
+            if len(args) == 1:
+                return f"f64({args[0]})"
+            return "0.0"
+
         elif func_name_str == "isinstance":
             if len(args) == 2:
                 obj = args[0]


### PR DESCRIPTION
Mapped the Python `float` builtin explicitly to V's `f64` type cast in `ExpressionsMixin.visit_Call`. If called with one argument, it translates `float(j)` into `f64(j)`. If called with no arguments, it returns `0.0`. Tested against existing and temporary test cases to ensure correct transposition into V source code without any regressions across the test suite.

---
*PR created automatically by Jules for task [10560962665513870375](https://jules.google.com/task/10560962665513870375) started by @yaskhan*