### PR TITLE
feat: map __len__ and __getitem__ to Vlang equivalents

### DIFF
--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -293,6 +293,10 @@ class FunctionsMixin(TranslatorBase):
                  func_name = "set"
             elif func_name == "__delete__":
                  func_name = "delete"
+            elif func_name == "__len__":
+                 func_name = "len"
+            elif func_name == "__getitem__":
+                 func_name = "idx"
 
             if dec_info.is_setter:
                  func_name = f"set_{func_name}"

--- a/py2v_transpiler/tests/translator/test_magic_methods.py
+++ b/py2v_transpiler/tests/translator/test_magic_methods.py
@@ -1,0 +1,42 @@
+import ast
+from typing import cast
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.parser import PyASTParser
+
+def transpile(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    return translator.visit_Module(cast(ast.Module, tree))
+
+def test_magic_methods_len_and_getitem():
+    code = """
+class Plan:
+    def __init__(self, constraints: list[int]):
+        self.constraints = constraints
+
+    def __len__(self) -> int:
+        return len(self.constraints)
+
+    def __getitem__(self, index: int) -> int:
+        return self.constraints[index]
+"""
+    v_code = transpile(code)
+
+    assert "fn (self Plan) len() int {" in v_code
+    assert "fn (self Plan) idx(index int) int {" in v_code
+
+def test_magic_methods_outside_class():
+    code = """
+def __len__(self) -> int:
+    return 1
+
+def __getitem__(self, index: int) -> int:
+    return index
+"""
+    v_code = transpile(code)
+
+    assert "fn len(self int) int {" in v_code
+    assert "fn idx(self int, index int) int {" in v_code


### PR DESCRIPTION
Fixes the magic methods mapping issue from todo2.md. `__len__` is now mapped to `len` (idiomatic `.len()` in V) and `__getitem__` is mapped to `idx` (index operator overloading in V). A new test file `test_magic_methods.py` was added to verify these mappings, and the full test suite runs without regressions.

---
*PR created automatically by Jules for task [7673239582754637370](https://jules.google.com/task/7673239582754637370) started by @yaskhan*