### PR TITLE
feat(translator): support startswith and endswith with tuples

### DIFF
--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -492,14 +492,14 @@ class ExpressionsMixin(TranslatorBase):
             return "os.input('')"
 
         # String predicates
-        # isdigit, isalpha, isalnum, isspace, islower, isupper, istitle
+        # isdigit, isalpha, isalnum, isspace, islower, isupper, istitle, startswith, endswith
         # These are usually called as methods on strings: "s.isdigit()"
         # But visit_Call handles method calls too.
         # Check if the function name matches a known string predicate.
         # And implicitly assume the receiver is a string (or we rely on V compiler error if not).
         # We handle them if func_node is Attribute.
         elif isinstance(func_node, ast.Attribute) and func_node.attr in (
-            "isdigit", "isalpha", "isalnum", "isspace", "islower", "isupper", "istitle"
+            "isdigit", "isalpha", "isalnum", "isspace", "islower", "isupper", "istitle", "startswith", "endswith"
         ) and not module_name:
              attr = func_node.attr
              obj = self.visit(func_node.value)
@@ -517,6 +517,23 @@ class ExpressionsMixin(TranslatorBase):
                  return f"{obj}.is_upper()"
              elif attr == "istitle":
                  return f"{obj}.is_title()"
+             elif attr in ("startswith", "endswith"):
+                 v_method = "starts_with" if attr == "startswith" else "ends_with"
+                 if len(node.args) == 1 and isinstance(node.args[0], ast.Tuple):
+                     checks = []
+                     for elt in node.args[0].elts:
+                         elt_str = self.visit(elt)
+                         checks.append(f"{obj}.{v_method}({elt_str})")
+                     return f"({' || '.join(checks)})"
+                 else:
+                     # Handled by standard mapping or method call fallback if not tuple
+                     # But for normal strings we might want to just output it here if we handled it
+                     # V uses starts_with/ends_with.
+                     if len(node.args) == 1:
+                         elt_str = self.visit(node.args[0])
+                         return f"{obj}.{v_method}({elt_str})"
+                     # Fallback to default if more complex
+                     pass
 
         elif func_name_str == "print":
             sep = " "

--- a/py2v_transpiler/tests/translator/test_string_predicates.py
+++ b/py2v_transpiler/tests/translator/test_string_predicates.py
@@ -65,3 +65,8 @@ def test_string_predicates_case_level():
 def test_string_predicates_literals():
     assert translate_expr("'123'.isdigit()") == "'123'.bytes().all(it.is_digit())"
     assert translate_expr("'abc'.isalpha()") == "'abc'.bytes().all(it.is_letter())"
+
+def test_string_predicates_startswith_endswith_tuple():
+    assert translate_expr("s.startswith(('a', 'b'))") == "(s.starts_with('a') || s.starts_with('b'))"
+    assert translate_expr("s.endswith(('x', 'y', 'z'))") == "(s.ends_with('x') || s.ends_with('y') || s.ends_with('z'))"
+    assert translate_expr("'hello'.startswith(('he', 'ha'))") == "('hello'.starts_with('he') || 'hello'.starts_with('ha'))"

--- a/todo2.md
+++ b/todo2.md
@@ -58,7 +58,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
   - Review if V's `regex` module supports these constructs, and if not, how `py2v_transpiler` maps Python's `re` module calls for these features.
 - [ ] **`OrderedDict` Performance**
   - Check how `collections.OrderedDict` is currently mapped. Since V's standard `map` is not guaranteed to be ordered, ensure `OrderedDict` maps to an ordered data structure in V if order is relied upon.
-- [ ] **String Methods on Tuples/Iterables (`str.startswith` with tuple)**
+- [x] **String Methods on Tuples/Iterables (`str.startswith` with tuple)**
   - Python allows `s.startswith(('a', 'b'))`. Ensure the translator expands this to `s.starts_with('a') || s.starts_with('b')` in V.
 - [ ] **Memoryview and Bytearray**
   - Implement translation for `memoryview()` and `bytearray()` (e.g., mapping to `[]u8` in V with appropriate mutable/immutable semantics).


### PR DESCRIPTION
Python allows `str.startswith` and `str.endswith` to accept a tuple of prefixes/suffixes.
This commit adds support for translating these cases into a logical OR of multiple
`starts_with` or `ends_with` checks in V.

For example, `s.startswith(('a', 'b'))` translates to
`(s.starts_with('a') || s.starts_with('b'))`.

Fixes the "String Methods on Tuples/Iterables" task in todo2.md.

---
*PR created automatically by Jules for task [10191502064866122572](https://jules.google.com/task/10191502064866122572) started by @yaskhan*