### PR TITLE
Fix constructor and super().__init__ generation in transpiler

### DIFF
--- a/py2v_transpiler/core/translator/expressions.py
+++ b/py2v_transpiler/core/translator/expressions.py
@@ -216,16 +216,21 @@ class ExpressionsMixin(TranslatorBase):
                  receiver = self.visit(func_node.value)
                  return f"{receiver}.unlock()"
 
-        # Handle super().method()
-        if isinstance(func_node, ast.Attribute) and isinstance(func_node.value, ast.Call) and \
-           isinstance(func_node.value.func, ast.Name) and func_node.value.func.id == "super":
-            # super().method(...)
-            method_name = func_node.attr
-            if self.current_class_bases:
-                parent = self.current_class_bases[0]
-                return f"self.{parent}.{method_name}({', '.join(args)})"
-            else:
-                 return f"/* super().{method_name} call without known parent */"
+        # Handle super().method() and super(Class, self).method()
+        if isinstance(func_node, ast.Attribute) and isinstance(func_node.value, ast.Call):
+            is_super = False
+            if isinstance(func_node.value.func, ast.Name) and func_node.value.func.id == "super":
+                is_super = True
+
+            if is_super:
+                method_name = func_node.attr
+                if self.current_class_bases:
+                    parent = self.current_class_bases[0]
+                    if method_name == "__init__":
+                        return f"self.{parent} = new_{parent}({', '.join(args)})"
+                    return f"self.{parent}.{method_name}({', '.join(args)})"
+                else:
+                    return f"/* super().{method_name} call without known parent */"
 
         # Handle unittest assertions
         # Strictly check for self.assertX if possible to avoid regressions

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -317,10 +317,12 @@ class FunctionsMixin(TranslatorBase):
             # Switch to generating implementation
             func_name = dec_info.implementation_name
 
+        is_init = False
         if 'decl' not in locals() and func_name == "__init_subclass__":
             receiver_str = ""
             func_name = "init_subclass"
         elif func_name == "__init__":
+            is_init = True
             func_name = f"new_{struct_name}"
             receiver_str = "" # Factory is static
             ret_type = struct_name
@@ -361,6 +363,11 @@ class FunctionsMixin(TranslatorBase):
         for line in dec_info.injected_end:
              self.output.append(f"{self._indent()}{line}")
 
+        prev_in_init = getattr(self, "in_init", False)
+        if is_init:
+            self.in_init = True
+            self.output.append(f"{self._indent()}mut self := {ret_type}{{}}")
+
         # Check for docstring
         body = node.body
         if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
@@ -380,6 +387,10 @@ class FunctionsMixin(TranslatorBase):
         if is_generator:
             self.output.append(f"{self._indent()}{self.coroutine_handler.active_channel}.close()")
             self.coroutine_handler.exit_generator()
+
+        if is_init:
+            self.output.append(f"{self._indent()}return self")
+            self.in_init = prev_in_init
 
         self._indent_level -= 1
         self.output.append("}")
@@ -533,7 +544,9 @@ class FunctionsMixin(TranslatorBase):
         for _ in range(self.vexc_depth):
              self.output.append(f"{self._indent()}vexc.end_try()")
 
-        if node.value:
+        if getattr(self, "in_init", False) and not node.value:
+            self.output.append(f"{self._indent()}return self")
+        elif node.value:
             val = self.visit(node.value)
             self.output.append(f"{self._indent()}return {val}")
         else:

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -298,7 +298,10 @@ class VariablesMixin(TranslatorBase):
                     else:
                         self.output.append(f"{self._indent()}mut {lhs} := ?Any(none)")
                 else:
-                    self.output.append(f"{self._indent()}{lhs} := {rhs}")
+                    if isinstance(target, ast.Attribute) or isinstance(target, ast.Subscript):
+                        self.output.append(f"{self._indent()}{lhs} = {rhs}")
+                    else:
+                        self.output.append(f"{self._indent()}{lhs} := {rhs}")
 
     def _visit_destructuring(self, target: ast.AST, source_expr: str) -> None:
         """
@@ -547,7 +550,10 @@ class VariablesMixin(TranslatorBase):
                 else:
                     # We ignore the annotation for now and rely on type inference and V's auto-typing
                     # But we could potentially use it to hint types for empty lists/maps
-                    self.output.append(f"{self._indent()}{target} := {rhs}")
+                    if isinstance(node.target, ast.Attribute) or isinstance(node.target, ast.Subscript):
+                        self.output.append(f"{self._indent()}{target} = {rhs}")
+                    else:
+                        self.output.append(f"{self._indent()}{target} := {rhs}")
         else:
             # Declaration only: x: int
             # V needs initialization. We map type to default value.

--- a/py2v_transpiler/tests/translator/test_classes.py
+++ b/py2v_transpiler/tests/translator/test_classes.py
@@ -32,11 +32,11 @@ class Point:
 
     # Check factory function for __init__
     assert "fn new_Point(x int, y int) Point {" in result
-    assert "self.x := x" in result
+    assert "self.x = x" in result
 
     # Check method
     assert "fn (self Point) move(dx int, dy int) {" in result
-    assert "self.x := self.x + dx" in result
+    assert "self.x = self.x + dx" in result
 
 def test_translator_class_usage():
     parser = PyASTParser()

--- a/py2v_transpiler/tests/translator/test_property_setter.py
+++ b/py2v_transpiler/tests/translator/test_property_setter.py
@@ -23,9 +23,7 @@ class Person:
         "return self._name",
         "}",
         "fn (self Person) set_name(value string) {",
-        # Note: self._name := value is currently generated due to VariablesMixin bug
-        # We check for the method signature renaming mainly.
-        "self._name :="
+            "self._name = value"
     ]
 
     visitor = VNodeVisitor(TypeInference())

--- a/todo2.md
+++ b/todo2.md
@@ -390,7 +390,7 @@ Based on the transpilation of the `bm_deltablue.py` benchmark, several critical 
   - *Context:* Python abstract base classes (e.g., `Constraint`) and their concrete implementations (`UrnaryConstraint`, `BinaryConstraint`) are currently transpiled using V struct embedding. However, V struct embedding does not support dynamic virtual method dispatch.
   - *Task:* Detect polymorphic base classes (especially those with `@abstractmethod`) and transpile them to V `interface`s, ensuring that method calls on base types dynamically dispatch to the concrete structs.
 
-- [ ] **Constructors and `super().__init__` Handling**
+- [x] **Constructors and `super().__init__` Handling**
   - *Context:* `super(StayConstraint, self).__init__(v, string)` is incorrectly emitted as `self.UrnaryConstraint.__init__(v, string)` inside a factory function where `self` is not even defined or allocated.
   - *Task:* Refactor constructor generation so that derived classes properly instantiate and return their base/embedded structs (e.g., `return StayConstraint{ UrnaryConstraint: new_UrnaryConstraint(...) }`), rather than relying on non-existent `__init__` methods.
 


### PR DESCRIPTION
This submission addresses the issue where `super().__init__` inside factory functions would generate invalid V code referencing an unallocated `self` and a non-existent `__init__` method.

Changes implemented:
1. `FunctionsMixin`: Automatically injects `mut self := StructName{}` at the top of generated `new_StructName` factory functions and `return self` at the bottom (including handling early `return` statements).
2. `ExpressionsMixin`: Detects `super().__init__` and `super(Class, self).__init__` calls and translates them to assigning a new embedded struct instance directly to the struct field (e.g., `self.Parent = new_Parent(...)`).
3. `VariablesMixin`: Fixes a bug where struct field assignments (e.g., `self.x = x`) were emitted with the initialization operator `:=`. Now emits the correct `=` assignment operator.
4. Cleaned up the local environment and marked the relevant task complete in `todo2.md`. All unit tests pass cleanly.

---
*PR created automatically by Jules for task [13533040139082066382](https://jules.google.com/task/13533040139082066382) started by @yaskhan*