### PR TITLE
Handle duplicate V method mapping for __str__ and __repr__

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -397,6 +397,12 @@ class ClassesMixin(TranslatorBase):
             struct_def += f"struct {struct_name}{generics_str} {{\n" + "\n".join(fields) + "\n}"
             self.emitter.add_struct(struct_def)
 
+            has_str = any(m.name == "__str__" for m in methods)
+            if has_str:
+                for method in methods:
+                    if method.name == "__repr__":
+                        method.name = "repr"
+
             # Visit methods to generate them as functions
             for method in methods:
                 self.visit(method)

--- a/py2v_transpiler/tests/translator/test_repr.py
+++ b/py2v_transpiler/tests/translator/test_repr.py
@@ -1,0 +1,55 @@
+import ast
+from py2v_transpiler.core.translator.classes import ClassesMixin
+from py2v_transpiler.core.translator.functions import FunctionsMixin
+from py2v_transpiler.core.translator.variables import VariablesMixin
+from py2v_transpiler.core.translator.expressions import ExpressionsMixin
+from py2v_transpiler.core.translator.literals import LiteralsMixin
+from py2v_transpiler.core.translator.base import TranslatorBase
+from py2v_transpiler.core.generator import VCodeEmitter
+from py2v_transpiler.core.decorators import DecoratorProcessor
+from py2v_transpiler.core.coroutines import CoroutineHandler
+from unittest.mock import MagicMock
+
+class DummyTranslator(ClassesMixin, FunctionsMixin, VariablesMixin, ExpressionsMixin, LiteralsMixin, TranslatorBase):
+    def __init__(self):
+        super().__init__(type_inference=MagicMock())
+        self.emitter = VCodeEmitter()
+        self.decorator_processor = DecoratorProcessor(self.emitter)
+        self.coroutine_handler = CoroutineHandler()
+        self.output = []
+        self._indent_level = 0
+        self.current_class = None
+        self.class_hierarchy = {}
+        self.known_interfaces = set()
+
+def test_repr_and_str_rename():
+    code = """
+class MyClass:
+    def __str__(self):
+        return "str"
+    def __repr__(self):
+        return "repr"
+"""
+    tree = ast.parse(code)
+    translator = DummyTranslator()
+    translator.visit(tree)
+
+    generated_code = translator.emitter.emit()
+
+    assert "fn (self MyClass) str() {" in generated_code
+    assert "fn (self MyClass) repr() {" in generated_code
+
+def test_repr_without_str():
+    code = """
+class MyClass2:
+    def __repr__(self):
+        return "repr"
+"""
+    tree = ast.parse(code)
+    translator = DummyTranslator()
+    translator.visit(tree)
+
+    generated_code = translator.emitter.emit()
+
+    assert "fn (self MyClass2) str() {" in generated_code
+    assert "fn (self MyClass2) repr() {" not in generated_code

--- a/todo2.md
+++ b/todo2.md
@@ -431,7 +431,7 @@ Based on the transpilation of the `bm_raytrace.py` benchmark, several critical a
   - *Context:* Constants like `DEFAULT_WIDTH := 100` and `Vector_ZERO := new_Vector(0, 0, 0)` are placed inside the generated `fn main()` block rather than an appropriate V `const ( ... )` block or global state.
   - *Task:* Refactor module-level assignment handling so that constants (e.g., `Final` or uppercase variables) are correctly emitted in a V `const` block (if compile-time evaluable) or an `init` block/global struct (if they require runtime instantiation like `new_Vector`).
 
-- [ ] **Duplicate Method Generation (`__str__` and `__repr__`)**
+- [x] **Duplicate Method Generation (`__str__` and `__repr__`)**
   - *Context:* Both `__str__` and `__repr__` methods on a Python class map to V's `.str() string` method, leading to compilation errors due to duplicate method declarations (e.g., `fn (self Vector) str() string { ... }` defined twice).
   - *Task:* Handle duplicate V method mapping by either combining `__str__` and `__repr__`, taking precedence of `__str__` over `__repr__`, or renaming `__repr__` to `repr()` instead of mapping both to `.str()`.
 


### PR DESCRIPTION
Resolves a compilation error when transpiling a Python class that defines both `__str__` and `__repr__` methods. The transpiler maps both to the V `.str()` method, causing duplicate method declarations.
This fix detects if a class defines `__str__`, and if so, safely renames `__repr__` to `repr` before method generation.
Includes tests to assert behavior for both collision and non-collision cases.

---
*PR created automatically by Jules for task [6706458480284818107](https://jules.google.com/task/6706458480284818107) started by @yaskhan*