### PR TITLE
Support overloading for magic methods

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -334,6 +334,27 @@ class CallsMixin(TranslatorBase):
                         best_match_suffix = "_".join(sig_suffix_parts)
                         break
 
+            # Operator overloading: if the method is an operator, don't mangle the call site,
+            # because V handles operators intrinsically if they are mapped correctly.
+            # But wait, python ast maps operators (e.g. `a + b`) to `BinOp(Add)`, which we already translate
+            # to `a + b` in `OperatorsMixin.visit_BinOp`.
+            # What if someone calls `a.__add__(b)` directly?
+            # V does not allow calling operators as methods (`a.+(b)`).
+            # We must map `__add__` to `+`.
+            op_map = {
+                "__add__": "+", "__sub__": "-", "__mul__": "*", "__truediv__": "/",
+                "__mod__": "%", "__lt__": "<", "__le__": "<=", "__eq__": "==",
+                "__ne__": "!="
+            }
+            if func_name_str in op_map:
+                op_str = op_map[func_name_str]
+                # If we are in obj.method(arg), then we need to restructure it to obj + arg
+                if len(args) == 1 and isinstance(node.func, ast.Attribute):
+                    obj = self.visit(node.func.value)
+                    return f"{obj} {op_str} {args[0]}"
+                # Fallback if something weird happened (e.g. called without args)
+                pass
+
             if best_match_suffix:
                 func_name_str = f"{func_name_str}_{best_match_suffix}"
             elif type_suffix_parts:

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -451,11 +451,26 @@ class FunctionsMixin(TranslatorBase):
             else:
                 func_name = f"{base_func_name}_noargs"
 
+            op_map = {
+                "__add__": "+", "__sub__": "-", "__mul__": "*", "__truediv__": "/",
+                "__mod__": "%", "__lt__": "<", "__le__": "<=", "__eq__": "==",
+                "__ne__": "!="
+            }
+            is_operator = False
+            op_str = ""
+            if is_method and node.name in op_map:
+                is_operator = True
+                op_str = op_map[node.name]
+                func_name = op_str
+
             self.function_names.add(func_name)
 
-            decl = f"fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
-            if ret_type == "void":
-                 decl = f"fn {receiver_str}{func_name}({args_str}) {{"
+            if is_operator:
+                decl = f"fn {receiver_str}{op_str} ({args_str}) {ret_type} {{"
+            else:
+                decl = f"fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
+                if ret_type == "void":
+                    decl = f"fn {receiver_str}{func_name}({args_str}) {{"
 
             self.output.append(decl)
             self._indent_level += 1

--- a/py2v_transpiler/tests/translator/test_overload_operators.py
+++ b/py2v_transpiler/tests/translator/test_overload_operators.py
@@ -1,0 +1,46 @@
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def translate(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    if not isinstance(tree, ast.Module):
+        raise ValueError("Parsed AST is not a Module")
+    analyzer = TypeInference()
+    analyzer.visit(tree) # Run type inference first
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+    helpers = translator.emitter.emit_helpers()
+    return v_code + "\n" + helpers
+
+def test_overload_add_operator():
+    source = """
+from typing import overload
+
+class Vector:
+    @overload
+    def __add__(self, other: 'Vector') -> 'Vector':
+        pass
+
+    @overload
+    def __add__(self, other: int) -> 'Vector':
+        pass
+
+    def __add__(self, other):
+        return self
+"""
+    v_code = translate(source)
+    print("------- V CODE -------")
+    print(v_code)
+    print("----------------------")
+    # Both overloads should be emitted as overloaded operators?
+    # V actually does NOT support multiple overloaded operators for the same type if LHS is same?
+    # Wait, V operator overloading signature is:
+    # fn (a T) + (b U) R
+    # Can we have both `fn (a Vector) + (b Vector) Vector` and `fn (a Vector) + (b int) Vector`?
+    # Yes! V supports overloading operators with different RHS types.
+
+    assert "fn (self Vector) + (other Vector) Vector {" in v_code
+    assert "fn (self Vector) + (other int) Vector {" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -419,7 +419,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
 ## Analysis of `bm_raytrace.py` Transpilation Issues
 Based on the transpilation of the `bm_raytrace.py` benchmark, several critical areas for improvement have been identified:
 
-- [ ] **Magic Methods with Overloads (`__add__`, `__sub__`, etc.)**
+- [x] **Magic Methods with Overloads (`__add__`, `__sub__`, etc.)**
   - *Context:* Python's magic methods like `__add__` with `@overload` are currently emitted as uniquely named functions (e.g., `__add___Vector` or `__add___Point`) instead of V's overloaded operators (`+`). Normal magic methods like `__sub__` correctly map to V's `-` operator, but overloaded ones do not fallback or combine into operator overloads properly.
   - *Task:* Ensure that when overloaded magic methods are encountered, they map correctly to V's operator overloading syntax (e.g. `fn (a Vector) + (b Vector) Vector`), generating multiple overloaded operators if V supports them, or handling type disjunctions cleanly.
 


### PR DESCRIPTION
Implemented the ability to map overloaded Python magic methods directly to V operator overloading syntax (e.g., `fn (a Vector) + (b Vector) Vector`), generating multiple overloaded operators if V supports them. Also handles correctly parsing those methods if called directly by translating them to expressions (`a + b`).

---
*PR created automatically by Jules for task [3726229136893348292](https://jules.google.com/task/3726229136893348292) started by @yaskhan*