### PR TITLE
Fix Type Inference for Module-Level Dictionaries and Tuple Values

### DIFF
--- a/py2v_transpiler/core/analyzer.py
+++ b/py2v_transpiler/core/analyzer.py
@@ -66,6 +66,40 @@ class TypeInference(ast.NodeVisitor):
         self.type_map.update(alias_inferer.alias_to_type)
         return self.type_map
 
+
+    def visit_Assign(self, node: ast.Assign) -> Any:
+        for target in node.targets:
+            if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name):
+                dict_name = target.value.id
+
+                key_type = "string" # default key
+                if hasattr(target.slice, "value") and isinstance(target.slice.value, ast.Constant): # python < 3.9
+                    if isinstance(target.slice.value.value, int): key_type = "int"
+                    elif isinstance(target.slice.value.value, str): key_type = "string"
+                elif isinstance(target.slice, ast.Constant): # python 3.9+
+                    if isinstance(target.slice.value, int): key_type = "int"
+                    elif isinstance(target.slice.value, str): key_type = "string"
+
+                val_type = "Any"
+                if isinstance(node.value, ast.Constant):
+                    if isinstance(node.value.value, int): val_type = "int"
+                    elif isinstance(node.value.value, str): val_type = "string"
+                elif isinstance(node.value, ast.Tuple):
+                    if node.value.elts:
+                        if isinstance(node.value.elts[0], ast.Constant):
+                            if isinstance(node.value.elts[0].value, int): val_type = "[]int"
+                            elif isinstance(node.value.elts[0].value, str): val_type = "[]string"
+                            else: val_type = "[]Any"
+                        else:
+                            val_type = "[]Any"
+                    else:
+                        val_type = "[]Any"
+
+                new_type = f"map[{key_type}]{val_type}"
+                self.type_map[dict_name] = new_type
+
+        self.generic_visit(node)
+
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
         # Check if the target is a simple variable name (ast.Name)
         if isinstance(node.target, ast.Name):

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -68,9 +68,10 @@ class VariablesMixin(TranslatorBase):
                 # Check if LHS is capitalized (heuristic)
                 if lhs[0].isupper():
                      # Check if it was inferred by TypeInference (e.g. OrderedCollection = list)
-                     if hasattr(self, 'type_inference') and lhs in self.type_inference.type_map:
+                     if hasattr(self, 'type_inference') and lhs in self.type_inference.type_map and isinstance(node.value, ast.Name):
                           is_type_alias = True
                           type_alias_val = self.type_inference.type_map[lhs]
+
                      else:
                           # Try to map RHS as a type
                           try:
@@ -275,8 +276,13 @@ class VariablesMixin(TranslatorBase):
 
                 rhs = f"{v_type}{{{', '.join(pairs)}}}"
                 self.output.append(f"{self._indent()}{lhs} := {rhs}")
+
             else:
-                rhs = self.visit(node.value)
+                if isinstance(node.value, ast.Dict) and not node.value.keys and v_type.startswith("map["):
+                    rhs = f"{v_type}{{}}"
+                else:
+                    rhs = self.visit(node.value)
+
 
                 if self.in_main and isinstance(target, ast.Name):
                     if lhs in getattr(self, "global_vars", set()):
@@ -526,8 +532,13 @@ class VariablesMixin(TranslatorBase):
 
                 rhs = f"{v_type}{{{', '.join(pairs)}}}"
                 self.output.append(f"{self._indent()}{target} := {rhs}")
+
             else:
-                rhs = self.visit(node.value)
+                if isinstance(node.value, ast.Dict) and not node.value.keys and v_type.startswith("map["):
+                    rhs = f"{v_type}{{}}"
+                else:
+                    rhs = self.visit(node.value)
+
 
                 if self.in_main and isinstance(node.target, ast.Name):
                     target_name = target

--- a/todo2.md
+++ b/todo2.md
@@ -400,7 +400,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
   - *Context:* Functions from `six` (`u as u_lit`, `text_type`) are emitted directly, resulting in undefined V functions.
   - *Task:* Add AST node interception or standard library mapping for common `six` module utilities, translating `text_type(x)` to `x.str()` and bypassing `u_lit` wrappers for string literals.
 
-- [ ] **Type Inference for Module-Level Dictionaries and Tuple Values**
+- [x] **Type Inference for Module-Level Dictionaries and Tuple Values**
   - *Context:* The `LEVELS` global dictionary is inferred as `map[string]int{}`, but is populated with integer keys and string-tuple values (e.g., `LEVELS[2] = ("...", "...")`).
   - *Task:* Improve type inference for dictionaries populated by subsequent index assignments (`dict[key] = value`). Correctly map Python tuples to V structs, arrays, or multiple return values when used as dictionary values.
 


### PR DESCRIPTION
This change addresses an issue where module-level dictionaries populated with index assignments were incorrectly inferred as `map[string]int{}` and failed to handle tuple values.

- Enhanced `TypeInference.visit_Assign` to capture type information from index assignments.
- Handled tuple mapping to `[]type` arrays in the AST analyzer.
- Improved the initialization behavior in `VariablesMixin.visit_Assign` to utilize the inferred type for empty dictionary instantiations rather than always falling back to `map[string]int{}`.
- Refined the type alias detection logic to ensure variables like `LEVELS = {}` do not incorrectly trigger alias definitions in the emitted V code.

Tested extensively with the project's test suite and several manual edge cases. Checked off the corresponding task in `todo2.md`.

---
*PR created automatically by Jules for task [5035304321433504232](https://jules.google.com/task/5035304321433504232) started by @yaskhan*