### PR TITLE
Add Modulo % String Formatting Support

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -77,6 +77,9 @@ class TranslatorBase(ast.NodeVisitor):
             inferred = self.type_inference.resolve_type(node)
             if inferred != "void":
                 return inferred
+            # Try to see if it's in our local map
+            if hasattr(self.type_inference, "type_map") and node.id in self.type_inference.type_map:
+                return self.type_inference.type_map[node.id]
             return "int" # Fallback
         elif isinstance(node, ast.BinOp):
             if isinstance(node.op, ast.Div):

--- a/py2v_transpiler/core/translator/expressions_split/operators.py
+++ b/py2v_transpiler/core/translator/expressions_split/operators.py
@@ -116,6 +116,23 @@ class OperatorsMixin(TranslatorBase):
                  is_string_fmt = True
              elif left_type == "string":
                  is_string_fmt = True
+             # Extended checks to robustly identify string formatting:
+             if isinstance(node.left, ast.Name):
+                 inferred = self.type_inference.resolve_type(node.left)
+                 if inferred == "string":
+                     is_string_fmt = True
+                 elif node.left.id in self.type_inference.type_map and self.type_inference.type_map[node.left.id] == "string":
+                     is_string_fmt = True
+             elif isinstance(node.left, ast.BinOp) and self._guess_type(node.left) == "string":
+                 is_string_fmt = True
+             elif isinstance(node.left, ast.Attribute) and self._guess_type(node.left) == "string":
+                 is_string_fmt = True
+
+             # Fallback check: if we are still unsure about the left operand but we know the right operand is a string or a tuple
+             # we can reasonably assume the user intended string formatting if the left operand is not definitively a number.
+             if not is_string_fmt and left_type not in ("int", "f64", "float", "i64"):
+                 if right_type == "string" or isinstance(node.right, ast.Tuple):
+                     is_string_fmt = True
 
              if is_string_fmt:
                  self.used_string_format = True

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -254,6 +254,15 @@ class VariablesMixin(TranslatorBase):
             # Determine type
             v_type = getattr(self, "_guess_type", lambda x: "unknown")(target)
 
+            # Update type map on normal assignment if type is unknown or we have a literal
+            if isinstance(target, ast.Name):
+                assigned_type = getattr(self, "_guess_type", lambda x: "unknown")(node.value)
+                if assigned_type != "unknown" and assigned_type != "int":
+                    if hasattr(self, 'type_inference') and hasattr(self.type_inference, 'type_map'):
+                        # If not already statically typed, save the literal assigned type
+                        if target.id not in self.type_inference.type_map:
+                            self.type_inference.type_map[target.id] = assigned_type
+
             if is_simple_list and v_type.startswith("[]") and cap > 0:
                 # To initialize V arrays with exact capacities (`[]int{cap: N}`) during assignments like `arr = [x, y, z]`
                 # We emit:

--- a/todo2.md
+++ b/todo2.md
@@ -412,7 +412,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
   - *Context:* `bm_hexiom.py` uses `StringIO` for stream output, which maps directly to undefined `StringIO` and `IO[string]` types in V.
   - *Task:* Map `io.StringIO` (and `six.moves.StringIO`) to V's `strings.Builder`. Map `IO[str]` to `&strings.Builder` or an appropriate stream interface in V.
 
-- [ ] **Modulo `%` String Formatting**
+- [x] **Modulo `%` String Formatting**
   - *Context:* Python's string formatting `"%s " % c` is emitted directly as `'%s ' % c`, which is invalid syntax in V.
   - *Task:* Intercept the `%` binary operator when the left operand is a string, and transpile it to V's string interpolation (e.g., `'$c '`) or generate calls using V's `fmt` module.
 


### PR DESCRIPTION
Intercept the Python `%` binary operator when used as a string formatter and correctly map it to `py_string_format` in Vlang instead of using V's `%` operator, which only supports numbers. The logic extends type mapping for literals dynamically to prevent misinterpreting variables without type annotations.

---
*PR created automatically by Jules for task [16315200728281117942](https://jules.google.com/task/16315200728281117942) started by @yaskhan*