### PR TITLE
Fix Module-Level Dictionary Initialization Scope

### DIFF
--- a/py2v_transpiler/core/generator.py
+++ b/py2v_transpiler/core/generator.py
@@ -6,6 +6,7 @@ class VCodeEmitter:
         self.structs: List[str] = []
         self.functions: List[str] = []
         self.main_body: List[str] = []
+        self.init_body: List[str] = []
         self.globals: List[str] = []
         self.constants: List[str] = []
 
@@ -56,6 +57,10 @@ class VCodeEmitter:
         """Adds a function definition to helpers."""
         self.helper_functions.append(func_def)
 
+    def add_init_statement(self, stmt: str) -> None:
+        """Adds a statement to the init function body."""
+        self.init_body.append(stmt)
+
     def add_main_statement(self, stmt: str) -> None:
         """Adds a statement to the main function body."""
         self.main_body.append(stmt)
@@ -86,6 +91,11 @@ class VCodeEmitter:
         if self.functions:
             lines.extend(self.functions)
             lines.append("")
+
+        if self.init_body:
+            lines.append("fn init() {")
+            lines.extend(["    " + line for line in self.init_body])
+            lines.append("}\n")
 
         if self.main_body:
             lines.append("fn main() {")

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -278,30 +278,43 @@ class VariablesMixin(TranslatorBase):
             else:
                 rhs = self.visit(node.value)
 
-                if self.in_main and isinstance(target, ast.Name):
-                    if lhs in getattr(self, "global_vars", set()):
-                        if v_type == "unknown":
-                            v_type = "Any"
-                        self.emitter.add_global(f"{lhs} {v_type}")
-                        self.output.append(f"{self._indent()}{lhs} = {rhs}")
-                    elif lhs.isupper():
-                        self.emitter.add_constant(f"{lhs} = {rhs}")
-                    else:
-                        self.output.append(f"{self._indent()}{lhs} := {rhs}")
-                if rhs == "none":
+                emit_fn = self.output.append
+                if self.in_main:
+                    base_lhs = lhs.split('.')[0].split('[')[0]
+
+                    if base_lhs in getattr(self, "global_vars", set()):
+                        emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+                        if isinstance(target, ast.Name):
+                            if v_type == "unknown":
+                                v_type = "Any"
+                            self.emitter.add_global(f"{lhs} {v_type}")
+                    elif base_lhs.isupper():
+                        emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+                        if isinstance(target, ast.Name):
+                            if v_type == "unknown":
+                                v_type = "Any"
+                            self.emitter.add_global(f"{lhs} {v_type}")
+
+                if self.in_main and isinstance(target, ast.Name) and (lhs in getattr(self, "global_vars", set()) or lhs.isupper()):
+                    emit_fn(f"{self._indent()}{lhs} = {rhs}")
+                elif rhs == "none":
                     # v_type might be defined above if we were checking is_simple_list, but let's be safe
                     local_v_type = getattr(self, "_guess_type", lambda x: "unknown")(target)
                     if local_v_type and local_v_type != "unknown":
                         if not local_v_type.startswith("?"):
                             local_v_type = f"?{local_v_type}"
-                        self.output.append(f"{self._indent()}mut {lhs} := {local_v_type}(none)")
+                        emit_fn(f"{self._indent()}mut {lhs} := {local_v_type}(none)")
                     else:
-                        self.output.append(f"{self._indent()}mut {lhs} := ?Any(none)")
+                        emit_fn(f"{self._indent()}mut {lhs} := ?Any(none)")
                 else:
                     if isinstance(target, ast.Attribute) or isinstance(target, ast.Subscript):
-                        self.output.append(f"{self._indent()}{lhs} = {rhs}")
+                        emit_fn(f"{self._indent()}{lhs} = {rhs}")
                     else:
-                        self.output.append(f"{self._indent()}{lhs} := {rhs}")
+                        if emit_fn == self.output.append:
+                            emit_fn(f"{self._indent()}{lhs} := {rhs}")
+                        else:
+                            # if it's going to init(), it shouldn't be := if it's a global
+                            emit_fn(f"{self._indent()}{lhs} = {rhs}")
 
     def _visit_destructuring(self, target: ast.AST, source_expr: str) -> None:
         """
@@ -426,24 +439,26 @@ class VariablesMixin(TranslatorBase):
             for stmt in setup_stmts:
                 self.output.append(stmt)
 
+            emit_fn = self.output.append
+            if self.in_main:
+                base_target = new_target.split('.')[0].split('[')[0]
+                if base_target in getattr(self, "global_vars", set()) or base_target.isupper():
+                    emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+
             if isinstance(node.op, ast.Pow):
                 self.emitter.add_import("math")
                 target_type = self._guess_type(node.target) if hasattr(self, '_guess_type') else "unknown"
                 if target_type == "int":
-                     self.output.append(f"{self._indent()}{new_target} = int(math.pow({new_target}, {value}))")
+                     emit_fn(f"{self._indent()}{new_target} = int(math.pow({new_target}, {value}))")
                 else:
-                     self.output.append(f"{self._indent()}{new_target} = math.pow({new_target}, {value})")
+                     emit_fn(f"{self._indent()}{new_target} = math.pow({new_target}, {value})")
             elif isinstance(node.op, ast.FloorDiv):
-                # //= -> floor division
-                # If types are int, use math.floor(f64(a)/f64(b)) cast to int to match Python
-                # If types are float, use math.floor(a/b)
                 target_type = self._guess_type(node.target) if hasattr(self, '_guess_type') else "unknown"
                 self.emitter.add_import("math")
                 if target_type == "f64" or target_type == "float":
-                     self.output.append(f"{self._indent()}{new_target} = math.floor({new_target} / {value})")
+                     emit_fn(f"{self._indent()}{new_target} = math.floor({new_target} / {value})")
                 else:
-                     # Integer division (safe floor div)
-                     self.output.append(f"{self._indent()}{new_target} = int(math.floor(f64({new_target}) / f64({value})))")
+                     emit_fn(f"{self._indent()}{new_target} = int(math.floor(f64({new_target}) / f64({value})))")
             return
 
         target = self.visit(node.target)
@@ -452,14 +467,21 @@ class VariablesMixin(TranslatorBase):
             ast.Add: "+=", ast.Sub: "-=", ast.Mult: "*=", ast.Div: "/=",
             ast.Mod: "%="
         }
+
+        emit_fn = self.output.append
+        if self.in_main:
+            base_target = target.split('.')[0].split('[')[0]
+            if base_target in getattr(self, "global_vars", set()) or base_target.isupper():
+                emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+
         # V supports +=, -=, *=, /=, %=
         op_str = op_map.get(type(node.op))
         if op_str:
-             self.output.append(f"{self._indent()}{target} {op_str} {value}")
+             emit_fn(f"{self._indent()}{target} {op_str} {value}")
         elif isinstance(node.op, ast.MatMult):
-             self.output.append(f"{self._indent()}{target} = {target}.matmul({value})")
+             emit_fn(f"{self._indent()}{target} = {target}.matmul({value})")
         else:
-             self.output.append(f"{self._indent()}// Unsupported AugAssign operator: {type(node.op)}")
+             emit_fn(f"{self._indent()}// Unsupported AugAssign operator: {type(node.op)}")
 
     def visit_Delete(self, node: ast.Delete) -> None:
         # Support for multiple delete targets (e.g. del a, b)
@@ -529,31 +551,42 @@ class VariablesMixin(TranslatorBase):
             else:
                 rhs = self.visit(node.value)
 
-                if self.in_main and isinstance(node.target, ast.Name):
-                    target_name = target
-                    if not v_type or v_type == "unknown":
-                        v_type = "Any"
-                    if target_name in getattr(self, "global_vars", set()):
-                        self.emitter.add_global(f"{target_name} {v_type}")
-                        self.output.append(f"{self._indent()}{target_name} = {rhs}")
-                    elif target_name.isupper():
-                        self.emitter.add_constant(f"{target_name} = {rhs}")
-                    else:
-                        self.output.append(f"{self._indent()}{target} := {rhs}")
-                if rhs == "none":
+                emit_fn = self.output.append
+                if self.in_main:
+                    base_lhs = target.split('.')[0].split('[')[0]
+
+                    if base_lhs in getattr(self, "global_vars", set()):
+                        emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+                        if isinstance(node.target, ast.Name):
+                            if not v_type or v_type == "unknown":
+                                v_type = "Any"
+                            self.emitter.add_global(f"{target} {v_type}")
+                    elif base_lhs.isupper():
+                        emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
+                        if isinstance(node.target, ast.Name):
+                            if not v_type or v_type == "unknown":
+                                v_type = "Any"
+                            self.emitter.add_global(f"{target} {v_type}")
+
+                if self.in_main and isinstance(node.target, ast.Name) and (target in getattr(self, "global_vars", set()) or target.isupper()):
+                    emit_fn(f"{self._indent()}{target} = {rhs}")
+                elif rhs == "none":
                     if v_type and v_type != "unknown":
                         if not v_type.startswith("?"):
                             v_type = f"?{v_type}"
-                        self.output.append(f"{self._indent()}mut {target} := {v_type}(none)")
+                        emit_fn(f"{self._indent()}mut {target} := {v_type}(none)")
                     else:
-                        self.output.append(f"{self._indent()}mut {target} := ?Any(none)")
+                        emit_fn(f"{self._indent()}mut {target} := ?Any(none)")
                 else:
                     # We ignore the annotation for now and rely on type inference and V's auto-typing
                     # But we could potentially use it to hint types for empty lists/maps
                     if isinstance(node.target, ast.Attribute) or isinstance(node.target, ast.Subscript):
-                        self.output.append(f"{self._indent()}{target} = {rhs}")
+                        emit_fn(f"{self._indent()}{target} = {rhs}")
                     else:
-                        self.output.append(f"{self._indent()}{target} := {rhs}")
+                        if emit_fn == self.output.append:
+                            emit_fn(f"{self._indent()}{target} := {rhs}")
+                        else:
+                            emit_fn(f"{self._indent()}{target} = {rhs}")
         else:
             # Declaration only: x: int
             # V needs initialization. We map type to default value.

--- a/todo2.md
+++ b/todo2.md
@@ -404,7 +404,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
   - *Context:* The `LEVELS` global dictionary is inferred as `map[string]int{}`, but is populated with integer keys and string-tuple values (e.g., `LEVELS[2] = ("...", "...")`).
   - *Task:* Improve type inference for dictionaries populated by subsequent index assignments (`dict[key] = value`). Correctly map Python tuples to V structs, arrays, or multiple return values when used as dictionary values.
 
-- [ ] **Module-Level Dictionary Initialization Scope**
+- [x] **Module-Level Dictionary Initialization Scope**
   - *Context:* `LEVELS[2] = ...` assignments are placed inside the generated `fn main()`, trapping the global state in a local scope.
   - *Task:* Ensure that module-level collection mutations (like dict assignments) are placed in a V `fn init()` block or a `__global` initialization routine so that global constants are properly populated and accessible to other functions.
 


### PR DESCRIPTION
Resolves the issue where module-level collection assignments (e.g. dict initializations) were placed inside the generated `fn main()`, trapping global state.

- Modified `VCodeEmitter` to support `add_init_statement` and emit an `fn init() {}` block.
- Updated `VariablesMixin` in `py2v_transpiler/core/translator/variables.py` to route `visit_Assign`, `visit_AnnAssign`, and `visit_AugAssign` to `init()` when mutating or assigning to known globals or uppercase constants.
- Updated `todo2.md` to mark "Module-Level Dictionary Initialization Scope" as done.

---
*PR created automatically by Jules for task [2925330293463371640](https://jules.google.com/task/2925330293463371640) started by @yaskhan*