### PR TITLE
feat: Add support for six module string helpers

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -69,6 +69,12 @@ class CallsMixin(TranslatorBase):
                  module_name = "builtins" # synthetic
                  func_name = func_node.id
 
+        if module_name == "six":
+            if func_name == "u" and len(args) == 1:
+                return args[0]
+            elif func_name == "text_type" and len(args) == 1:
+                return f"{args[0]}.str()"
+
         if module_name == "os" and func_name == "open":
              # Handle open() -> os.open()
              self.emitter.add_import("os")

--- a/py2v_transpiler/tests/translator/test_six.py
+++ b/py2v_transpiler/tests/translator/test_six.py
@@ -1,0 +1,52 @@
+import ast
+from py2v_transpiler.core.translator.expressions_split.calls import CallsMixin
+from py2v_transpiler.core.translator.literals import LiteralsMixin
+from py2v_transpiler.core.translator.base import TranslatorBase
+from py2v_transpiler.models.v_types import map_python_type_to_v
+
+class DummyEmitter:
+    def __init__(self):
+        self.imports = set()
+    def add_import(self, imp):
+        self.imports.add(imp)
+
+class DummyMapper:
+    def get_mapping(self, mod, func, args):
+        return None
+
+class DummyTypeInference:
+    call_signatures = {}
+
+class DummyCoroutineHandler:
+    def is_generator(self, name):
+        return False
+
+class TestTranslator(CallsMixin, LiteralsMixin, TranslatorBase):
+    def __init__(self):
+        super().__init__(type_inference=DummyTypeInference())
+        self.emitter = DummyEmitter()
+        self.mapper = DummyMapper()
+        self.type_inference = DummyTypeInference()
+        self.coroutine_handler = DummyCoroutineHandler()
+        self.imported_modules = {"six": "six"}
+        self.imported_symbols = {"u": "six.u", "text_type": "six.text_type"}
+
+def test_six_u():
+    trans = TestTranslator()
+    node = ast.parse("six.u('abc')").body[0].value
+    res = trans.visit_Call(node)
+    assert res == "'abc'"
+
+    node2 = ast.parse("u('abc')").body[0].value
+    res2 = trans.visit_Call(node2)
+    assert res2 == "'abc'"
+
+def test_six_text_type():
+    trans = TestTranslator()
+    node = ast.parse("six.text_type(123)").body[0].value
+    res = trans.visit_Call(node)
+    assert res == "123.str()"
+
+    node2 = ast.parse("text_type(123)").body[0].value
+    res2 = trans.visit_Call(node2)
+    assert res2 == "123.str()"

--- a/todo2.md
+++ b/todo2.md
@@ -396,7 +396,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
   - *Context:* Comprehensions such as `[self.cells[i][:] for i in range(self.count)]` and generator expressions inside functions like `max(...)` or `sum(...)` emit `/* unknown */` or `// List comprehension expression not supported inline yet`.
   - *Task:* Implement full support for inline list comprehensions and generator expressions, mapping them to V's `map`/`filter` array methods, or extracting them into inline loops or closure helpers.
 
-- [ ] **`six` Module and Legacy Compatibility Helpers**
+- [x] **`six` Module and Legacy Compatibility Helpers**
   - *Context:* Functions from `six` (`u as u_lit`, `text_type`) are emitted directly, resulting in undefined V functions.
   - *Task:* Add AST node interception or standard library mapping for common `six` module utilities, translating `text_type(x)` to `x.str()` and bypassing `u_lit` wrappers for string literals.
 


### PR DESCRIPTION
Fixes undefined V functions emitted for `six.u` and `six.text_type` by correctly translating them to V's native string expressions.

---
*PR created automatically by Jules for task [11022992809797298702](https://jules.google.com/task/11022992809797298702) started by @yaskhan*