### PR TITLE
Map `platform.python_implementation()` to literal string `'V'`

### DIFF
--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -180,6 +180,7 @@ class StdLibMapper:
             "platform": {
                 "system": "os.user_os",
                 "machine": "py_platform_machine",
+                "python_implementation": self._platform_python_implementation,
             },
             "hashlib": {
                 "sha256": "py_hash_sha256",
@@ -586,3 +587,6 @@ class StdLibMapper:
     def _typing_cast(self, args: List[str]) -> str:
         # We handle this directly in expressions.py now for type resolution
         return "/* typing.cast intercepted by expressions.py */"
+
+    def _platform_python_implementation(self, args: List[str]) -> str:
+        return "'V'"

--- a/todo2.md
+++ b/todo2.md
@@ -478,7 +478,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* `print` statements with `file=sys.stderr` are transpiled to standard `println`.
   - *Task:* Recognize `file=sys.stderr` in `print` calls and map them to V's `eprintln`.
 
-- [ ] **Missing Modules (`platform`)**
+- [x] **Missing Modules (`platform`)**
   - *Context:* `platform.python_implementation()` is emitted directly but `platform` doesn't exist in V.
   - *Task:* Provide an AST mapping or standard library mock for `platform.python_implementation()` returning `'V'` or similar.
 ## Analysis of `bm_spectral_norm.py` Transpilation Issues


### PR DESCRIPTION
- Adds mapping for `platform.python_implementation` in `StdLibMapper`.
- Checks off the `Missing Modules (platform)` task in `todo2.md`.
- No new regressions introduced across the test suite.

---
*PR created automatically by Jules for task [11367071736809727037](https://jules.google.com/task/11367071736809727037) started by @yaskhan*