### PR TITLE
Fix string iteration in `for` loops by mapping bytes (`u8`) to characters (`string`)

### DIFF
--- a/py2v_transpiler/core/translator/control_flow.py
+++ b/py2v_transpiler/core/translator/control_flow.py
@@ -106,10 +106,24 @@ class ControlFlowMixin(TranslatorBase):
         # Push loop context to stack for break handling
         self.loop_stack.append({'vexc_depth': self.vexc_depth})
 
-        self.output.append(f"{self._indent()}for {target} in {iter_expr} {{")
-        self._indent_level += 1
-        for stmt in node.body:
-            self.visit(stmt)
+        # Handle string iteration: V yields u8 for strings, so we convert using .ascii_str()
+        is_string_iter = False
+        if isinstance(node.iter, ast.Call) and getattr(node.iter.func, 'id', '') == "str":
+            is_string_iter = True
+        elif hasattr(self, '_guess_type') and self._guess_type(node.iter) == "string":
+            is_string_iter = True
+
+        if is_string_iter:
+            self.output.append(f"{self._indent()}for {target}_u8 in {iter_expr} {{")
+            self._indent_level += 1
+            self.output.append(f"{self._indent()}{target} := {target}_u8.ascii_str()")
+            for stmt in node.body:
+                self.visit(stmt)
+        else:
+            self.output.append(f"{self._indent()}for {target} in {iter_expr} {{")
+            self._indent_level += 1
+            for stmt in node.body:
+                self.visit(stmt)
         self._indent_level -= 1
         self.output.append(f"{self._indent()}}}")
 
@@ -221,10 +235,24 @@ class ControlFlowMixin(TranslatorBase):
                      else:
                          self.output.append(f"{self._indent()}// TODO: handle enumerate with single target variable")
 
-        self.output.append(f"{self._indent()}for {target} in {iter_expr} {{")
-        self._indent_level += 1
-        for stmt in node.body:
-            self.visit(stmt)
+        # Handle string iteration: V yields u8 for strings, so we convert using .ascii_str()
+        is_string_iter = False
+        if isinstance(node.iter, ast.Call) and getattr(node.iter.func, 'id', '') == "str":
+            is_string_iter = True
+        elif hasattr(self, '_guess_type') and self._guess_type(node.iter) == "string":
+            is_string_iter = True
+
+        if is_string_iter:
+            self.output.append(f"{self._indent()}for {target}_u8 in {iter_expr} {{")
+            self._indent_level += 1
+            self.output.append(f"{self._indent()}{target} := {target}_u8.ascii_str()")
+            for stmt in node.body:
+                self.visit(stmt)
+        else:
+            self.output.append(f"{self._indent()}for {target} in {iter_expr} {{")
+            self._indent_level += 1
+            for stmt in node.body:
+                self.visit(stmt)
         self._indent_level -= 1
         self.output.append(f"{self._indent()}}}")
 

--- a/todo2.md
+++ b/todo2.md
@@ -454,7 +454,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* In `Node.__init__`, `self.children = {}` causes `self.children` to be inferred as `map[string]int{}`, which is incorrect since it stores `Node` instances later.
   - *Task:* Improve type inference for empty dictionaries by analyzing subsequent dictionary assignments (like `head.children[ch] = Node()`) to infer the correct value type (`map[string]Node`).
 
-- [ ] **String Iteration (`for ch in str(el):`)**
+- [x] **String Iteration (`for ch in str(el):`)**
   - *Context:* Iterating over a string in V yields bytes (`u8`), but the Python code expects string characters to be used as map keys (`head.children[ch]`).
   - *Task:* Handle string iteration correctly by mapping the iterated byte to a string (e.g., using a custom iterator or `.ascii_str()`) when the string semantics are required.
 


### PR DESCRIPTION
Fixes string iteration in `for` loops. V yields `u8` bytes when iterating a string, but Python expects string characters. Added an AST check in `ControlFlowMixin.visit_For` to intercept string iterations (using `str()` or `_guess_type`) and automatically generate `.ascii_str()` extraction within the V `for` block. 
Also marked the task as completed in `todo2.md`.

---
*PR created automatically by Jules for task [13503093002433895952](https://jules.google.com/task/13503093002433895952) started by @yaskhan*