### PR TITLE
Support sys.stderr redirection for print calls

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -585,6 +585,7 @@ class CallsMixin(TranslatorBase):
         elif func_name_str == "print":
             sep = " "
             end = "\\n"
+            is_stderr = False
 
             for keyword in node.keywords:
                 if keyword.arg == "sep":
@@ -595,6 +596,10 @@ class CallsMixin(TranslatorBase):
                         end = keyword.value.value
                         if end == "\n":
                             end = "\\n"
+                elif keyword.arg == "file":
+                    file_val = self.visit(keyword.value)
+                    if file_val == "sys.stderr":
+                        is_stderr = True
 
             parts = []
             for arg in node.args:
@@ -607,12 +612,20 @@ class CallsMixin(TranslatorBase):
 
             joined_content = sep.join(parts)
 
-            if end == "\\n":
-                return f"println('{joined_content}')"
-            elif end == "":
-                return f"print('{joined_content}')"
+            if is_stderr:
+                if end == "\\n":
+                    return f"eprintln('{joined_content}')"
+                elif end == "":
+                    return f"eprint('{joined_content}')"
+                else:
+                    return f"eprint('{joined_content}{end}')"
             else:
-                return f"print('{joined_content}{end}')"
+                if end == "\\n":
+                    return f"println('{joined_content}')"
+                elif end == "":
+                    return f"print('{joined_content}')"
+                else:
+                    return f"print('{joined_content}{end}')"
 
         # Check if it is a generator call
         if self.coroutine_handler.is_generator(func_name_str):

--- a/py2v_transpiler/tests/translator/test_print.py
+++ b/py2v_transpiler/tests/translator/test_print.py
@@ -48,3 +48,15 @@ print(x, y, sep=', ')
     v_code = translate(source)
     # x and y are vars, so ${x} and ${y}
     assert "println('${x}, ${y}')" in v_code
+
+def test_print_stderr():
+    source = """
+import sys
+print('Error', file=sys.stderr)
+print('Error', file=sys.stderr, end='')
+print('Error', file=sys.stderr, end='!')
+"""
+    v_code = translate(source)
+    assert "eprintln('Error')" in v_code
+    assert "eprint('Error')" in v_code
+    assert "eprint('Error!')" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -474,7 +474,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* `bytes(msg, "utf8")` is emitted as `bytes(msg, 'utf8')`.
   - *Task:* Map `bytes(string, encoding)` to V's native `string.bytes()` method.
 
-- [ ] **`sys.stderr` Redirection (`print(..., file=sys.stderr)`)**
+- [x] **`sys.stderr` Redirection (`print(..., file=sys.stderr)`)**
   - *Context:* `print` statements with `file=sys.stderr` are transpiled to standard `println`.
   - *Task:* Recognize `file=sys.stderr` in `print` calls and map them to V's `eprintln`.
 


### PR DESCRIPTION
Support sys.stderr redirection for print calls

Updated CallsMixin in expressions_split/calls.py to detect when a print
call has `file=sys.stderr`. When this keyword argument is present, the
transpiler now generates V's `eprintln` (or `eprint` if an end argument
is provided) rather than standard `println`.

Also checked off the associated task in todo2.md and added a new unit
test for standard error prints.

---
*PR created automatically by Jules for task [11457579029270364869](https://jules.google.com/task/11457579029270364869) started by @yaskhan*