### PR TITLE
Fix truth value testing for collections in while loops

### DIFF
--- a/py2v_transpiler/core/translator/control_flow.py
+++ b/py2v_transpiler/core/translator/control_flow.py
@@ -18,6 +18,10 @@ class ControlFlowMixin(TranslatorBase):
         self._walrus_assignments = []
         test_expr = self.visit(node.test)
 
+        node_type = self._guess_type(node.test)
+        if node_type.startswith("[]") or node_type.startswith("map[") or node_type == "string":
+            test_expr = f"{test_expr}.len > 0"
+
         if self._walrus_assignments:
              for assign in self._walrus_assignments:
                  self.output.append(f"{self._indent()}{assign}")
@@ -61,6 +65,10 @@ class ControlFlowMixin(TranslatorBase):
 
         self._walrus_assignments = []
         test_expr = self.visit(node.test)
+
+        node_type = self._guess_type(node.test)
+        if node_type.startswith("[]") or node_type.startswith("map[") or node_type == "string":
+            test_expr = f"{test_expr}.len > 0"
 
         if self._walrus_assignments:
              # Found walrus! Transform loop.

--- a/py2v_transpiler/tests/translator/test_while_collection.py
+++ b/py2v_transpiler/tests/translator/test_while_collection.py
@@ -1,0 +1,83 @@
+import ast
+from py2v_transpiler.core.translator import TranslatorBase, ControlFlowMixin
+from py2v_transpiler.core.generator import VCodeEmitter
+from typing import Any
+
+class DummyTypeInference:
+    def __init__(self, mapping):
+        self.type_map = mapping
+        self.location_map = {}
+
+    def resolve_type(self, node):
+        if isinstance(node, ast.Name) and node.id in self.type_map:
+            return self.type_map[node.id]
+        return "void"
+
+class DummyTranslator(ControlFlowMixin):
+    def __init__(self, mapping):
+        super().__init__(DummyTypeInference(mapping))
+        self.emitter = VCodeEmitter()
+
+    def visit(self, node):
+        if isinstance(node, ast.Name):
+            return node.id
+        elif isinstance(node, ast.Constant):
+            return str(node.value).lower() if isinstance(node.value, bool) else str(node.value)
+        return super().visit(node)
+
+def test_while_queue_truth_value():
+    # while queue:
+    node = ast.While(
+        test=ast.Name(id="queue", ctx=ast.Load()),
+        body=[ast.Expr(value=ast.Constant(value=1))],
+        orelse=[]
+    )
+
+    translator = DummyTranslator({"queue": "[]int"})
+    translator.visit_While(node)
+
+    v_code = "\n".join(translator.output)
+
+    assert "for queue.len > 0 {" in v_code
+
+def test_while_dict_truth_value():
+    node = ast.While(
+        test=ast.Name(id="my_dict", ctx=ast.Load()),
+        body=[ast.Expr(value=ast.Constant(value=1))],
+        orelse=[]
+    )
+
+    translator = DummyTranslator({"my_dict": "map[string]int"})
+    translator.visit_While(node)
+
+    v_code = "\n".join(translator.output)
+
+    assert "for my_dict.len > 0 {" in v_code
+
+def test_while_string_truth_value():
+    node = ast.While(
+        test=ast.Name(id="s", ctx=ast.Load()),
+        body=[ast.Expr(value=ast.Constant(value=1))],
+        orelse=[]
+    )
+
+    translator = DummyTranslator({"s": "string"})
+    translator.visit_While(node)
+
+    v_code = "\n".join(translator.output)
+
+    assert "for s.len > 0 {" in v_code
+
+def test_while_bool_unchanged():
+    node = ast.While(
+        test=ast.Name(id="is_active", ctx=ast.Load()),
+        body=[ast.Expr(value=ast.Constant(value=1))],
+        orelse=[]
+    )
+
+    translator = DummyTranslator({"is_active": "bool"})
+    translator.visit_While(node)
+
+    v_code = "\n".join(translator.output)
+
+    assert "for is_active {" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -458,7 +458,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* Iterating over a string in V yields bytes (`u8`), but the Python code expects string characters to be used as map keys (`head.children[ch]`).
   - *Task:* Handle string iteration correctly by mapping the iterated byte to a string (e.g., using a custom iterator or `.ascii_str()`) when the string semantics are required.
 
-- [ ] **Truth Value Testing for Arrays/Queues (`while queue:`)**
+- [x] **Truth Value Testing for Arrays/Queues (`while queue:`)**
   - *Context:* `while queue:` is transpiled directly to `for queue {`, which is invalid in V.
   - *Task:* Map truth value testing of collections (lists, dicts, etc.) to explicit `.len > 0` checks in V (e.g., `for queue.len > 0 {`).
 


### PR DESCRIPTION
This commit resolves an issue where implicit truth value testing for collections in Python `while` loops (e.g., `while queue:`) was transpiled directly to `for queue {`, which is invalid syntax in Vlang.

Changes:
- Modified `visit_While` in `py2v_transpiler/core/translator/control_flow.py` to check the inferred type of the test expression using `self._guess_type(node.test)`.
- If the type is determined to be an array, map, or string, the transpiler now explicitly appends a `.len > 0` check (e.g., `for queue.len > 0 {`).
- Added test cases in `py2v_transpiler/tests/translator/test_while_collection.py` to verify this behavior for queues (arrays), dicts (maps), strings, and booleans.
- Marked the task as completed in `todo2.md`.

---
*PR created automatically by Jules for task [1236965023923438385](https://jules.google.com/task/1236965023923438385) started by @yaskhan*