### PR TITLE
Fix Python dict.items() iteration transpilation

### DIFF
--- a/py2v_transpiler/core/translator/control_flow.py
+++ b/py2v_transpiler/core/translator/control_flow.py
@@ -175,6 +175,12 @@ class ControlFlowMixin(TranslatorBase):
         target = self.visit(node.target)
         iter_expr = self.visit(node.iter)
 
+        if isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Attribute) and node.iter.func.attr == "items":
+            if isinstance(node.target, ast.Tuple):
+                if target.startswith("[") and target.endswith("]"):
+                    target = target[1:-1]
+            iter_expr = self.visit(node.iter.func.value)
+
         if isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Name):
              if node.iter.func.id == "range":
                  range_args = node.iter.args

--- a/test_dict_items2.py
+++ b/test_dict_items2.py
@@ -1,0 +1,3 @@
+top = {"a": 1, "b": 2}
+for ch, v in top.items():
+    print(ch, v)

--- a/todo2.md
+++ b/todo2.md
@@ -462,7 +462,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* `while queue:` is transpiled directly to `for queue {`, which is invalid in V.
   - *Task:* Map truth value testing of collections (lists, dicts, etc.) to explicit `.len > 0` checks in V (e.g., `for queue.len > 0 {`).
 
-- [ ] **Iterating over Dictionary Items (`for ch, v in top.children.items():`)**
+- [x] **Iterating over Dictionary Items (`for ch, v in top.children.items():`)**
   - *Context:* Emits `for [ch, v] in top.children.items() {` which is not idiomatic V.
   - *Task:* Map `.items()` iteration on maps directly to V's native map iteration syntax: `for ch, v in top.children {`.
 


### PR DESCRIPTION
This fixes a bug where `for k,v in dict.items()` was being translated to `for [k,v] in dict.items()` which is invalid V map iteration syntax. It now properly transpiles to `for k, v in dict {`.

---
*PR created automatically by Jules for task [2152049286645197433](https://jules.google.com/task/2152049286645197433) started by @yaskhan*