### PR TITLE
feat: support list replication `[x] * N`

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/operators.py
+++ b/py2v_transpiler/core/translator/expressions_split/operators.py
@@ -44,6 +44,22 @@ class OperatorsMixin(TranslatorBase):
         if isinstance(node.op, ast.MatMult):
              return f"{left}.matmul({right})"
 
+        if isinstance(node.op, ast.Mult):
+             if isinstance(node.left, ast.List) and len(node.left.elts) == 1:
+                  init_val = self.visit(node.left.elts[0])
+                  length = right
+                  elem_type = self._guess_type(node.left.elts[0])
+                  if init_val == "none":
+                       elem_type = "?Any"
+                  return f"[]{elem_type}{{len: {length}, init: {init_val}}}"
+             elif isinstance(node.right, ast.List) and len(node.right.elts) == 1:
+                  init_val = self.visit(node.right.elts[0])
+                  length = left
+                  elem_type = self._guess_type(node.right.elts[0])
+                  if init_val == "none":
+                       elem_type = "?Any"
+                  return f"[]{elem_type}{{len: {length}, init: {init_val}}}"
+
         # Check for bytes formatting: b"%s" % b"a"
         if isinstance(node.op, ast.Mod):
              # Heuristic: check if left operand is likely bytes

--- a/py2v_transpiler/tests/translator/test_todo_tasks.py
+++ b/py2v_transpiler/tests/translator/test_todo_tasks.py
@@ -120,5 +120,14 @@ x: int = 1
         self.assertNotIn("import __future__", result)
         self.assertIn("x := 1", result)
 
+    def test_list_replication(self):
+        source = """
+a = [1] * 10
+b = 5 * [None]
+"""
+        result = self.transpile(source)
+        self.assertIn("a := []int{len: 10, init: 1}", result)
+        self.assertIn("b := []?Any{len: 5, init: none}", result)
+
 if __name__ == '__main__':
     unittest.main()

--- a/todo2.md
+++ b/todo2.md
@@ -492,7 +492,7 @@ Based on the transpilation of the `bm_spectral_norm.py` benchmark, several criti
   - *Context:* `[func((i, u)) for i in xrange(len(list(u)))]` emits `// List comprehension expression not supported inline yet` and returns `None` (which is invalid in V).
   - *Task:* Implement full support for inline list comprehensions, either mapping them to V's array methods (`.map()`, `.filter()`) or extracting them into inline closures or helper variables.
 
-- [ ] **List Replication (`[x] * N`)**
+- [x] **List Replication (`[x] * N`)**
   - *Context:* `[1] * DEFAULT_N` is emitted directly as `[1] * DEFAULT_N`, which is not valid V array repetition syntax.
   - *Task:* Transpile Python list repetition into V's array initialization syntax with `len` and `init` (e.g., `[]int{len: DEFAULT_N, init: 1}`).
 


### PR DESCRIPTION
Implements the transpilation of Python list replication (e.g. `[x] * N`) into V's native array initialization syntax (`[]T{len: N, init: x}`). This provides correct, alloc-efficient Vlang arrays for replicated lists instead of emitting invalid V code.

Closes "List Replication" task from `todo2.md`.

---
*PR created automatically by Jules for task [11638566540185848643](https://jules.google.com/task/11638566540185848643) started by @yaskhan*