### PR TITLE
Fix string to integer conversion mapping

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -485,6 +485,20 @@ class CallsMixin(TranslatorBase):
                 return f"f64({args[0]})"
             return "0.0"
 
+        elif func_name_str == "int":
+            if len(args) == 0:
+                return "0"
+            elif len(args) == 1:
+                arg_type = self._guess_type(node.args[0])
+                if arg_type == "string":
+                    return f"{args[0]}.int()"
+                return f"int({args[0]})"
+            elif len(args) == 2:
+                # E.g. int('ff', 16) - V has strconv.parse_int
+                # but let's keep it simple or use strconv if required
+                self.emitter.add_import("strconv")
+                return f"int(strconv.parse_int({args[0]}, {args[1]}, 32) or {{ 0 }})"
+
         elif func_name_str == "isinstance":
             if len(args) == 2:
                 obj = args[0]

--- a/py2v_transpiler/tests/translator/test_builtins.py
+++ b/py2v_transpiler/tests/translator/test_builtins.py
@@ -42,3 +42,16 @@ for x in reversed(sorted(a)):
     assert "for x in py_reversed(py_sorted(a)) {" in v_code
     assert "fn py_sorted" in v_code
     assert "fn py_reversed" in v_code
+
+def test_int_builtin():
+    source = """
+a = int("123")
+b = int(3.14)
+c = int()
+d = int("ff", 16)
+"""
+    v_code = translate(source)
+    assert "a := '123'.int()" in v_code
+    assert "b := int(3.14)" in v_code
+    assert "c := 0" in v_code
+    assert "d := int(strconv.parse_int('ff', 16, 32) or { 0 })" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -466,7 +466,7 @@ Based on the transpilation of the `primes.py` benchmark, several critical areas 
   - *Context:* Emits `for [ch, v] in top.children.items() {` which is not idiomatic V.
   - *Task:* Map `.items()` iteration on maps directly to V's native map iteration syntax: `for ch, v in top.children {`.
 
-- [ ] **String to Integer Conversion (`int(prefix)`)**
+- [x] **String to Integer Conversion (`int(prefix)`)**
   - *Context:* `int(prefix)` where `prefix` is a string is emitted literally, but V requires `prefix.int()`.
   - *Task:* Map `int()` casts on string variables to the `.int()` method in V.
 


### PR DESCRIPTION
Currently, `int(prefix)` where `prefix` is a string is emitted literally, but V requires `prefix.int()`. This PR modifies `visit_Call` in `py2v_transpiler/core/translator/expressions_split/calls.py` to properly map `int()` invocations.

---
*PR created automatically by Jules for task [18420196852067580502](https://jules.google.com/task/18420196852067580502) started by @yaskhan*