### PR TITLE
Support array initialization via list multiplication and fix precedence parens

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -66,10 +66,10 @@ class TranslatorBase(ast.NodeVisitor):
 
     def _guess_type(self, node: ast.AST) -> str:
         if isinstance(node, ast.Constant):
+             if isinstance(node.value, bool): return "bool"
              if isinstance(node.value, int): return "int"
              if isinstance(node.value, float): return "f64"
              if isinstance(node.value, str): return "string"
-             if isinstance(node.value, bool): return "bool"
              if isinstance(node.value, complex): return "PyComplex"
              return "int"
         elif isinstance(node, ast.Name):

--- a/py2v_transpiler/core/translator/expressions_split/operators.py
+++ b/py2v_transpiler/core/translator/expressions_split/operators.py
@@ -16,8 +16,22 @@ class OperatorsMixin(TranslatorBase):
             if v_type != "void":
                  op_type = v_type
 
+        # Support for array initialization: [element] * length
+        if isinstance(node.op, ast.Mult) and isinstance(node.left, ast.List) and len(node.left.elts) == 1:
+            elt = node.left.elts[0]
+            elt_type = self._guess_type(elt)
+
+            elt_str = self.visit(elt)
+            right_str = self.visit(node.right)
+            return f"[]{elt_type}{{len: {right_str}, init: {elt_str}}}"
+
         left = self.visit(node.left)
+        if isinstance(node.left, (ast.BinOp, ast.BoolOp, ast.Compare)):
+            left = f"({left})"
+
         right = self.visit(node.right)
+        if isinstance(node.right, (ast.BinOp, ast.BoolOp, ast.Compare)):
+            right = f"({right})"
 
         # If mypy successfully inferred a concrete primitive numeric type (e.g. f64) for the operation,
         # and the operands' inferred types are not correctly matching or they are unknown ('Any'),
@@ -154,7 +168,12 @@ class OperatorsMixin(TranslatorBase):
     def visit_BoolOp(self, node: ast.BoolOp) -> str:
         op_map = {ast.And: "&&", ast.Or: "||"}
         op_str = op_map.get(type(node.op), "and")
-        values = [str(self.visit(val)) for val in node.values]
+        values = []
+        for val in node.values:
+            val_str = str(self.visit(val))
+            if isinstance(val, (ast.BoolOp, ast.BinOp, ast.Compare)):
+                val_str = f"({val_str})"
+            values.append(val_str)
         return f" {op_str} ".join(values)
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> str:

--- a/py2v_transpiler/tests/translator/test_basics.py
+++ b/py2v_transpiler/tests/translator/test_basics.py
@@ -26,7 +26,7 @@ def test_translator_binop():
     analyzer.analyze(tree)
     result = translator.visit_Module(tree)
 
-    assert "x := 1 + 2 * 3" in result
+    assert "x := 1 + (2 * 3)" in result
 
 def test_translator_bool_op():
     parser = PyASTParser()


### PR DESCRIPTION
Implemented array initialization logic to correctly transpile Python list multiplication (`[False] * N`) into Vlang's native array initialization syntax `[]bool{len: N, init: false}`. Also fixed several missing parenthesis bugs during unparsing where nested binary/boolean expressions lost explicit grouping, restoring proper evaluation precedence, and fixed the type guesser incorrectly classifying boolean constants as integers.

---
*PR created automatically by Jules for task [4619658166743166394](https://jules.google.com/task/4619658166743166394) started by @yaskhan*