### PR TITLE
Fix time.time() mapping precision to f64

### DIFF
--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -39,7 +39,7 @@ class StdLibMapper:
                 "dumps": "json.encode",
             },
             "time": {
-                "time": "time.now().unix",
+                "time": self._time_time,
                 "sleep": self._time_sleep,
             },
             "datetime": {
@@ -372,6 +372,11 @@ class StdLibMapper:
              # Default to map[string]string for generic JSON object
              return f"json.decode(map[string]string, {args[0]}) or {{}}"
         return "/* json.loads args error */"
+
+    def _time_time(self, args: List[str]) -> str:
+        if len(args) == 0:
+            return "f64(time.now().unix_time_milli()) / 1000.0"
+        return "/* time.time args error */"
 
     def _time_sleep(self, args: List[str]) -> str:
         if len(args) == 1:

--- a/todo2.md
+++ b/todo2.md
@@ -504,7 +504,7 @@ Based on the transpilation of the `bm_spectral_norm.py` benchmark, several criti
   - *Context:* `for ue, ve in izip(u, v):` emits `for [ue, ve] in izip(u, v) {`, which is invalid V syntax.
   - *Task:* Fix tuple unpacking syntax inside V `for` loop assignments, likely requiring translation to indexed loops or `arrays.zip()`.
 
-- [ ] **`time.time()` Precision Mapping**
+- [x] **`time.time()` Precision Mapping**
   - *Context:* `time.time()` maps to `time.now().unix()`, returning an integer (seconds), losing the fractional millisecond precision expected in Python benchmarking.
   - *Task:* Map `time.time()` to a V equivalent that returns an `f64` timestamp, such as `f64(time.now().unix_time_milli()) / 1000.0`.
 


### PR DESCRIPTION
Updates the StdLibMapper for Python's `time.time()` to generate Vlang
code that returns an f64 fractional timestamp (`f64(time.now().unix_time_milli()) / 1000.0`),
preserving millisecond precision required for benchmarks. Also updates `todo2.md`
to mark the task as completed.

---
*PR created automatically by Jules for task [7576369507967463579](https://jules.google.com/task/7576369507967463579) started by @yaskhan*