### PR TITLE
fix: transpile explicit base class constructor calls correctly

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -229,6 +229,15 @@ class CallsMixin(TranslatorBase):
                 else:
                     return f"/* super().{method_name} call without known parent */"
 
+        # Handle explicit BaseClass.__init__(self, ...)
+        if isinstance(func_node, ast.Attribute) and func_node.attr == "__init__":
+            if isinstance(func_node.value, ast.Name):
+                class_name = func_node.value.id
+                if self.current_class_bases and class_name in self.current_class_bases:
+                    if len(args) >= 1 and args[0] == "self":
+                        base_args = args[1:]
+                        return f"self.{class_name} = new_{class_name}({', '.join(base_args)})"
+
         # Handle unittest assertions
         # Strictly check for self.assertX if possible to avoid regressions
         # We check if receiver is "self"

--- a/todo2.md
+++ b/todo2.md
@@ -527,6 +527,6 @@ Based on the transpilation of the `bm_richards.py` benchmark, several critical a
   - *Context:* Mypy forward references like `Optional['Packet']` (or `Optional['Task']`) are failing to map accurately in the `else` block fallback type generation, falling back to `?int(none)` instead of `?Packet(none)`.
   - *Task:* Update type mapping to correctly resolve and strip string quotes from forward reference annotations like `'Packet'` so they properly map to their concrete V types.
 
-- [ ] **Explicit Base Class Constructor Calls (`Base.__init__`)**
+- [x] **Explicit Base Class Constructor Calls (`Base.__init__`)**
   - *Context:* Calls like `Task.__init__(self, i, p, w, s, r)` are emitted directly, which doesn't correctly update the embedded V struct unless the explicit embedded struct is initialized or fields are copied.
   - *Task:* Refactor explicit `BaseClass.__init__(self, ...)` calls to properly initialize the embedded struct fields inside the derived V struct.


### PR DESCRIPTION
When transpiling Python explicit base class constructors like `Task.__init__(self, i, p, w, s, r)`, the transpiler used to output it literally, which was syntactically invalid or failed to actually initialize the base fields of the embedded struct in V.

This patch adds logic to `calls.py` inside `visit_Call` to catch this specific pattern: `func_node` being an `ast.Attribute` for `__init__`, invoked on an `ast.Name` that matches an entry in `self.current_class_bases`, with the first argument being `self`. It translates this to the assignment `self.Task = new_Task(i, p, w, s, r)`.

Tested and confirmed working, also checked off the relevant line in `todo2.md`.

---
*PR created automatically by Jules for task [9196888771067370248](https://jules.google.com/task/9196888771067370248) started by @yaskhan*