### PR TITLE
Fix V array initialization for list repetitions with None

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/operators.py
+++ b/py2v_transpiler/core/translator/expressions_split/operators.py
@@ -56,14 +56,26 @@ class OperatorsMixin(TranslatorBase):
                   length = right
                   elem_type = self._guess_type(node.left.elts[0])
                   if init_val == "none":
-                       elem_type = "?Any"
+                       expected_type = getattr(self, "current_assignment_type", None)
+                       if expected_type and expected_type.startswith("[]"):
+                           elem_type = expected_type[2:]
+                           if not elem_type.startswith("?"):
+                               elem_type = f"?{elem_type}"
+                       else:
+                           elem_type = "?Any"
                   return f"[]{elem_type}{{len: {length}, init: {init_val}}}"
              elif isinstance(node.right, ast.List) and len(node.right.elts) == 1:
                   init_val = self.visit(node.right.elts[0])
                   length = left
                   elem_type = self._guess_type(node.right.elts[0])
                   if init_val == "none":
-                       elem_type = "?Any"
+                       expected_type = getattr(self, "current_assignment_type", None)
+                       if expected_type and expected_type.startswith("[]"):
+                           elem_type = expected_type[2:]
+                           if not elem_type.startswith("?"):
+                               elem_type = f"?{elem_type}"
+                       else:
+                           elem_type = "?Any"
                   return f"[]{elem_type}{{len: {length}, init: {init_val}}}"
 
         # Check for bytes formatting: b"%s" % b"a"

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -308,7 +308,10 @@ class VariablesMixin(TranslatorBase):
                 if isinstance(node.value, ast.Dict) and not node.value.keys and v_type.startswith("map["):
                     rhs = f"{v_type}{{}}"
                 else:
+                    self.current_assignment_type = v_type
                     rhs = self.visit(node.value)
+                    if hasattr(self, "current_assignment_type"):
+                        del self.current_assignment_type
 
                 emit_fn = self.output.append
                 if self.in_main:
@@ -593,7 +596,10 @@ class VariablesMixin(TranslatorBase):
                 if isinstance(node.value, ast.Dict) and not node.value.keys and v_type.startswith("map["):
                     rhs = f"{v_type}{{}}"
                 else:
+                    self.current_assignment_type = v_type
                     rhs = self.visit(node.value)
+                    if hasattr(self, "current_assignment_type"):
+                        del self.current_assignment_type
 
                 emit_fn = self.output.append
                 if self.in_main:

--- a/py2v_transpiler/tests/translator/test_array.py
+++ b/py2v_transpiler/tests/translator/test_array.py
@@ -32,3 +32,19 @@ a = array.array('d', [1.0, 2.0])
 """
     v_code = translate(source)
     assert "a := py_array('d', [1.0, 2.0])" in v_code
+
+def test_array_init_none_typed():
+    source = """
+from typing import Optional
+
+class Task:
+    pass
+
+a: list[Optional[Task]] = [None] * 5
+b: list[Task] = [None] * 10
+c = [None] * 15
+"""
+    v_code = translate(source)
+    assert "a := []?Task{len: 5, init: none}" in v_code
+    assert "b := []?Task{len: 10, init: none}" in v_code
+    assert "c := []?Any{len: 15, init: none}" in v_code

--- a/test_dict_items2.py
+++ b/test_dict_items2.py
@@ -1,3 +1,0 @@
-top = {"a": 1, "b": 2}
-for ch, v in top.items():
-    print(ch, v)

--- a/todo2.md
+++ b/todo2.md
@@ -515,7 +515,7 @@ Based on the transpilation of the `bm_richards.py` benchmark, several critical a
   - *Context:* Python method named `fn` (e.g., `def fn(self, pkt, r):`) is transpiled directly as `fn (self Task) fn(...)`, which causes a syntax error in V because `fn` is a reserved keyword.
   - *Task:* Implement an AST sanitization pass to rename or prefix Python identifiers that conflict with Vlang reserved keywords (e.g., mapping `fn` to `fn_` or `py_fn`).
 
-- [ ] **Array Initialization with `[None] * N`**
+- [x] **Array Initialization with `[None] * N`**
   - *Context:* Python's `[None] * TASKTABSIZE` is emitted directly as `[none] * TASKTABSIZE`, which is invalid V syntax for initializing arrays.
   - *Task:* Transpile list repetitions containing `None` into proper V array initialization (e.g., `[]?Task{len: TASKTABSIZE, init: none}`).
 


### PR DESCRIPTION
Fixes array initialization syntax in transpiler when multiplying lists containing `None` by integers, appropriately propagating V types.

---
*PR created automatically by Jules for task [14347282781797684410](https://jules.google.com/task/14347282781797684410) started by @yaskhan*