### PR TITLE
Fix mapping of string forward references in Python type hints

### DIFF
--- a/py2v_transpiler/models/v_types.py
+++ b/py2v_transpiler/models/v_types.py
@@ -18,6 +18,11 @@ def map_python_type_to_v(py_type: str, self_name: str = "Self", allow_union: boo
     if not py_type:
         return 'void'
 
+    # Strip surrounding quotes for forward references
+    if (py_type.startswith("'") and py_type.endswith("'")) or \
+       (py_type.startswith('"') and py_type.endswith('"')):
+        py_type = py_type[1:-1]
+
     # Pre-process basic types to avoid overhead
     if py_type == 'int': return 'int'
     if py_type == 'float': return 'f64'
@@ -50,6 +55,12 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Fa
             return 'none'
         if node.value is Ellipsis:
             return '...'
+        if isinstance(node.value, str):
+            try:
+                inner_node = ast.parse(node.value, mode='eval').body
+                return _map_ast_type(inner_node, self_name, allow_union)
+            except SyntaxError:
+                return node.value
         return str(node.value)
 
     elif isinstance(node, ast.Subscript):

--- a/py2v_transpiler/tests/translator/test_none_initialization.py
+++ b/py2v_transpiler/tests/translator/test_none_initialization.py
@@ -27,3 +27,8 @@ def test_none_initialization_optional():
     code = "planner: Optional[int] = None"
     v_code = transpile(code)
     assert "mut planner := ?int(none)" in v_code
+
+def test_none_initialization_optional_forward_ref():
+    code = "planner: Optional['Packet'] = None"
+    v_code = transpile(code)
+    assert "mut planner := ?Packet(none)" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -523,7 +523,7 @@ Based on the transpilation of the `bm_richards.py` benchmark, several critical a
   - *Context:* In `Task.runTask()`, a variable `msg` is initialized conditionally in `if/else` blocks (e.g., `msg := self.input` in `if`, `mut msg := ?int(none)` in `else`), making it inaccessible outside the blocks when passed to `return self.fn(msg, self.handle)`.
   - *Task:* Improve variable scoping generation. If a variable is conditionally declared and used outside the condition, pre-declare it as `mut` before the `if/else` block (e.g., `mut msg := ?Packet(none)`).
 
-- [ ] **`Optional` Type Inference with Forward References (`'Packet'`)**
+- [x] **`Optional` Type Inference with Forward References (`'Packet'`)**
   - *Context:* Mypy forward references like `Optional['Packet']` (or `Optional['Task']`) are failing to map accurately in the `else` block fallback type generation, falling back to `?int(none)` instead of `?Packet(none)`.
   - *Task:* Update type mapping to correctly resolve and strip string quotes from forward reference annotations like `'Packet'` so they properly map to their concrete V types.
 


### PR DESCRIPTION
- Stripped surrounding quotes from top-level strings inside `map_python_type_to_v`.
- Added recursive AST parsing using `ast.parse` for string `ast.Constant` values in `_map_ast_type` to correctly map stringified type components inside generic hints (e.g. `Optional['Task']` to `?Task`).
- Updated `todo2.md` task related to 'Packet' forward reference to `[x]`.
- Added a new unit test in `test_none_initialization.py` to test Optional forward reference correctly emits `?Packet(none)`.

---
*PR created automatically by Jules for task [3121700532703870855](https://jules.google.com/task/3121700532703870855) started by @yaskhan*