### PR TITLE
Add AST sanitization to fix V keyword collisions

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -107,6 +107,20 @@ class TranslatorBase(ast.NodeVisitor):
     def _indent(self) -> str:
         return "    " * self._indent_level
 
+    def _sanitize_name(self, name: str) -> str:
+        """
+        Sanitizes Python identifiers that collide with V lang reserved keywords.
+        """
+        reserved = {
+            "fn", "type", "struct", "mut", "if", "else", "for", "return", "match",
+            "interface", "enum", "pub", "import", "module", "const", "unsafe",
+            "defer", "go", "chan", "shared", "spawn", "assert", "sizeof", "typeof",
+            "__global", "as", "in", "is", "none", "map", "array", "string", "bool"
+        }
+        if name in reserved:
+            return f"py_{name}"
+        return name
+
     def _mangle_name(self, name: str, class_name: Optional[str]) -> str:
         """
         Implements Python's name mangling rules for private attributes.

--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -10,8 +10,8 @@ class ClassesMixin(TranslatorBase):
         if not hasattr(self, 'class_stack'):
             self.class_stack = []
 
-        self.class_stack.append(node.name)
-        struct_name = "_".join(self.class_stack)
+        self.class_stack.append(self._sanitize_name(node.name))
+        struct_name = self._sanitize_name("_".join(self.class_stack))
 
         # Pre-register class definition to allow class instantiation inside its own methods
         has_init = False
@@ -251,7 +251,7 @@ class ClassesMixin(TranslatorBase):
                 self.visit(stmt)
             elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
                 # Class attribute with annotation -> struct field
-                field_name = stmt.target.id
+                field_name = self._sanitize_name(stmt.target.id)
 
                 if field_name in added_fields:
                     continue
@@ -284,9 +284,9 @@ class ClassesMixin(TranslatorBase):
                          if isinstance(stmt.value, (ast.List, ast.Tuple)):
                              for elt in stmt.value.elts:
                                  if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-                                      slots_list.append(elt.value)
+                                      slots_list.append(self._sanitize_name(elt.value))
                          elif isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str):
-                             slots_list.append(stmt.value.value)
+                             slots_list.append(self._sanitize_name(stmt.value.value))
 
                          for slot in slots_list:
                              if slot not in added_fields:
@@ -324,11 +324,11 @@ class ClassesMixin(TranslatorBase):
              # Emit method signatures
              for method in methods:
                  # Manual extraction:
-                 m_name = method.name
+                 m_name = self._sanitize_name(method.name)
                  m_args = []
                  for arg in method.args.args:
                      if arg.arg == 'self': continue
-                     a_name = arg.arg
+                     a_name = self._sanitize_name(arg.arg)
                      a_type = "int"
                      if arg.annotation:
                           try:
@@ -369,7 +369,7 @@ class ClassesMixin(TranslatorBase):
                         for target in stmt.targets:
                             if isinstance(target, ast.Name):
                                 # snake_case conversion for member
-                                member_name = target.id.lower()
+                                member_name = self._sanitize_name(target.id.lower())
 
                                 # Check for auto()
                                 is_auto = False

--- a/py2v_transpiler/core/translator/expressions_split/attributes.py
+++ b/py2v_transpiler/core/translator/expressions_split/attributes.py
@@ -28,7 +28,7 @@ class AttributesMixin(TranslatorBase):
 
         # Mangling for self.__private attributes
         # We need to know if we are accessing self inside a class
-        attr_name = node.attr
+        attr_name = self._sanitize_name(node.attr)
         if self.current_class and isinstance(node.value, ast.Name):
             # Checking if the receiver is 'self' is tricky because 'self' is not guaranteed name.
             # But usually it is the first arg.
@@ -37,7 +37,7 @@ class AttributesMixin(TranslatorBase):
             # if the attribute starts with __
             # Wait, python mangles `self.__x` but also `other.__x` if inside Class.
             # So we apply mangling regardless of receiver, if we are inside a class.
-            attr_name = self._mangle_name(node.attr, self.current_class)
+            attr_name = self._sanitize_name(self._mangle_name(node.attr, self.current_class))
 
         # Check if obj corresponds to a known function (Function Attributes)
         # obj is already visited code, e.g. "func_name".

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -266,8 +266,17 @@ class CallsMixin(TranslatorBase):
 
         # Fallback to existing logic
         func_name_str = self.visit(node.func)
+
+        # If func_name_str was mangled/sanitized by visit_Name, we need the original to check builtins
+        # like "map", "filter", "print". Let's check if the un-sanitized version matches anything.
+        original_id = None
+        if isinstance(node.func, ast.Name):
+            original_id = node.func.id
+
         if func_name_str in self.renamed_functions:
             func_name_str = self.renamed_functions[func_name_str]
+        elif original_id and f"py_{original_id}" == func_name_str and original_id in ("map", "filter"):
+             func_name_str = original_id
 
         # Extract mypy plugin signature if available for this call
         loc_key = f"{getattr(node, 'lineno', 0)}:{getattr(node, 'col_offset', 0)}"
@@ -384,7 +393,7 @@ class CallsMixin(TranslatorBase):
             for keyword in node.keywords:
                 if keyword.arg:
                      kw_val_str = str(self.visit(keyword.value))
-                     struct_args.append(f"{keyword.arg}: {kw_val_str}")
+                     struct_args.append(f"{self._sanitize_name(keyword.arg)}: {kw_val_str}")
 
             return f"{func_name_str}{{{', '.join(struct_args)}}}"
 

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -42,7 +42,7 @@ class FunctionsMixin(TranslatorBase):
                 args = args[1:]
 
             for arg in args:
-                arg_name = arg.arg
+                arg_name = self._sanitize_name(arg.arg)
                 if arg.annotation:
                     try:
                         type_str = ast.unparse(arg.annotation)
@@ -212,7 +212,7 @@ class FunctionsMixin(TranslatorBase):
              args = args[1:]
 
         for arg in args:
-            arg_name = arg.arg
+            arg_name = self._sanitize_name(arg.arg)
             args_names.append(arg_name)
             # Use annotation if available for better type mapping
             if arg.annotation:
@@ -227,7 +227,7 @@ class FunctionsMixin(TranslatorBase):
             args_str_list.append(f"{arg_name} {arg_type}")
 
         if node.args.vararg:
-            arg_name = node.args.vararg.arg
+            arg_name = self._sanitize_name(node.args.vararg.arg)
             arg_type = "int" # Default
             if node.args.vararg.annotation:
                 try:
@@ -239,7 +239,7 @@ class FunctionsMixin(TranslatorBase):
             args_names.append(arg_name)
 
         if node.args.kwarg:
-            arg_name = node.args.kwarg.arg
+            arg_name = self._sanitize_name(node.args.kwarg.arg)
             arg_type = "map[string]string"
             if node.args.kwarg.annotation:
                 try:
@@ -276,7 +276,7 @@ class FunctionsMixin(TranslatorBase):
                  pass
 
         if not is_unittest_method:
-            func_name = node.name
+            func_name = self._sanitize_name(node.name)
 
             # Check if this is the implementation of an overloaded function
             if func_name in self.overloaded_signatures and not is_new_method:
@@ -431,7 +431,7 @@ class FunctionsMixin(TranslatorBase):
             # Generate mangled name based on argument types
             type_suffix_parts = []
             for arg in sig["args"]:
-                arg_name = arg["name"]
+                arg_name = self._sanitize_name(arg["name"])
                 arg_type = arg["type"]
                 args_str_list.append(f"{arg_name} {arg_type}")
                 args_names.append(arg_name)
@@ -442,9 +442,9 @@ class FunctionsMixin(TranslatorBase):
             args_str = ", ".join(args_str_list)
             ret_type = sig["return"]
 
-            base_func_name = node.name
+            base_func_name = self._sanitize_name(node.name)
             if self.current_class:
-                base_func_name = self._mangle_name(base_func_name, self.current_class)
+                base_func_name = self._sanitize_name(self._mangle_name(base_func_name, self.current_class))
 
             if type_suffix_parts:
                 func_name = f"{base_func_name}_{'_'.join(type_suffix_parts)}"
@@ -504,7 +504,7 @@ class FunctionsMixin(TranslatorBase):
         # lambda args: expr -> fn (args) { return expr }
         args_str_list = []
         for arg in node.args.args:
-            arg_name = arg.arg
+            arg_name = self._sanitize_name(arg.arg)
             arg_type = "int" # Default type for now
             args_str_list.append(f"{arg_name} {arg_type}")
 

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -26,7 +26,7 @@ class VariablesMixin(TranslatorBase):
         target = node.targets[0]
         lhs = ""
         if isinstance(target, ast.Name):
-            lhs = target.id
+            lhs = self._sanitize_name(target.id)
 
             # Check for NewType: UserId = NewType('UserId', int)
             if isinstance(node.value, ast.Call) and isinstance(node.value.func, ast.Name) and node.value.func.id == "NewType":
@@ -146,7 +146,7 @@ class VariablesMixin(TranslatorBase):
             if hasattr(self, 'dataclasses') and obj_type in self.dataclasses:
                 list_obj = self.visit(target.value)
                 if isinstance(target.slice, ast.Constant) and isinstance(target.slice.value, str):
-                    lhs = f"{list_obj}.{target.slice.value}"
+                    lhs = f"{list_obj}.{self._sanitize_name(target.slice.value)}"
                     rhs = self.visit(node.value)
                     self.output.append(f"{self._indent()}{lhs} = {rhs}")
                     return
@@ -297,7 +297,7 @@ class VariablesMixin(TranslatorBase):
                 pairs = []
                 for k, v in zip(node.value.keys, node.value.values):
                     if isinstance(k, ast.Constant) and isinstance(k.value, str):
-                        key_str = k.value
+                        key_str = self._sanitize_name(k.value)
                         val_str = self.visit(v)
                         pairs.append(f"{key_str}: {val_str}")
 
@@ -541,7 +541,7 @@ class VariablesMixin(TranslatorBase):
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> str:
         # (target := value)
-        target = node.target.id
+        target = self._sanitize_name(node.target.id)
         value = self.visit(node.value)
         self._walrus_assignments.append(f"{target} := {value}")
         return target
@@ -582,7 +582,7 @@ class VariablesMixin(TranslatorBase):
                 pairs = []
                 for k, v in zip(node.value.keys, node.value.values):
                     if isinstance(k, ast.Constant) and isinstance(k.value, str):
-                        key_str = k.value
+                        key_str = self._sanitize_name(k.value)
                         val_str = self.visit(v)
                         pairs.append(f"{key_str}: {val_str}")
 
@@ -687,10 +687,10 @@ class VariablesMixin(TranslatorBase):
             return self.name_remap[node.id]
 
         # Name mangling for class-private attributes
-        return self._mangle_name(node.id, self.current_class)
+        return self._sanitize_name(self._mangle_name(node.id, self.current_class))
 
     def visit_TypeAlias(self, node: Any) -> None:
-        name = node.name.id
+        name = self._sanitize_name(node.name.id)
         type_params = ""
 
         # Safe access to ast.TypeVar for Py < 3.12 compatibility

--- a/py2v_transpiler/tests/translator/test_keyword_collision.py
+++ b/py2v_transpiler/tests/translator/test_keyword_collision.py
@@ -1,0 +1,35 @@
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def translate(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    if not isinstance(tree, ast.Module):
+        raise ValueError("Parsed AST is not a Module")
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+    helpers = translator.emitter.emit_helpers()
+    return v_code + "\n" + helpers
+
+def test_keyword_collision():
+    source = """
+class Task:
+    def fn(self):
+        return 1
+
+    def mut(self, type, struct):
+        return type + struct
+
+fn = 1
+type = 2
+struct = 3
+"""
+    v_code = translate(source)
+    assert "fn (self Task) py_fn()" in v_code
+    assert "fn (self Task) py_mut(py_type int, py_struct int)" in v_code
+    assert "py_fn := 1" in v_code
+    assert "py_type := 2" in v_code
+    assert "py_struct := 3" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -511,7 +511,7 @@ Based on the transpilation of the `bm_spectral_norm.py` benchmark, several criti
 ## Analysis of `bm_richards.py` Transpilation Issues
 Based on the transpilation of the `bm_richards.py` benchmark, several critical areas for improvement have been identified:
 
-- [ ] **V Keyword Collision (`fn`)**
+- [x] **V Keyword Collision (`fn`)**
   - *Context:* Python method named `fn` (e.g., `def fn(self, pkt, r):`) is transpiled directly as `fn (self Task) fn(...)`, which causes a syntax error in V because `fn` is a reserved keyword.
   - *Task:* Implement an AST sanitization pass to rename or prefix Python identifiers that conflict with Vlang reserved keywords (e.g., mapping `fn` to `fn_` or `py_fn`).
 


### PR DESCRIPTION
Fixes an issue where Python identifiers that collide with Vlang reserved keywords (e.g., `fn`, `type`, `struct`, `mut`) caused syntax errors in the transpiled code. 

- Created `TranslatorBase._sanitize_name` method containing a list of V reserved keywords.
- Applied `_sanitize_name` across `FunctionsMixin`, `ClassesMixin`, `VariablesMixin`, and `AttributesMixin`.
- Updated `CallsMixin` to handle sanitized builtins (like `map`, `filter`).
- Added tests for keyword collision resolution.
- Updated `todo2.md`.

---
*PR created automatically by Jules for task [8408804538092666673](https://jules.google.com/task/8408804538092666673) started by @yaskhan*