### PR TITLE
🧹 Remove unused import `List` in `dependencies.py`

### DIFF
--- a/py2v_transpiler/core/dependencies.py
+++ b/py2v_transpiler/core/dependencies.py
@@ -1,6 +1,6 @@
 import ast
 import os
-from typing import Dict, Set, List
+from typing import Dict, Set
 
 class DependencyAnalyzer(ast.NodeVisitor):
     def __init__(self):


### PR DESCRIPTION
This change removes an unused `List` import from `py2v_transpiler/core/dependencies.py`. This is a minor code health improvement to maintain codebase cleanliness.

- Removed `List` from the typing import in `py2v_transpiler/core/dependencies.py`.
- Verified that all 54 tests pass.
- Confirmed that the module still compiles without syntax errors.

---
*PR created automatically by Jules for task [16873892810548714650](https://jules.google.com/task/16873892810548714650) started by @yaskhan*