### PR TITLE
🔒 Fix Command Injection in subprocess helpers

### DIFF
--- a/py2v_transpiler/core/translator/module.py
+++ b/py2v_transpiler/core/translator/module.py
@@ -485,15 +485,11 @@ class ModuleMixin(TranslatorBase):
              self.emitter.add_helper_struct("struct PyCompletedProcess {\n    returncode int\n    stdout string\n    stderr string\n}")
 
              # py_subprocess_run(args []string) PyCompletedProcess
-             # os.execute(cmd string) returns Result.
-             # We need to join args. V's os.execute takes a string command.
-             # Joining args with spaces is naive but standard for simple shells.
-             # Better: os.new_process? But that's more complex.
-             # For now, simplistic join.
-             self.emitter.add_helper_function("fn py_subprocess_run(args []string) PyCompletedProcess {\n    cmd := args.join(' ')\n    res := os.execute(cmd)\n    return PyCompletedProcess{returncode: res.exit_code, stdout: res.output, stderr: ''}\n}")
+             # Using os.new_process for security (avoiding shell injection)
+             self.emitter.add_helper_function("fn py_subprocess_run(args []string) PyCompletedProcess {\n    if args.len == 0 { return PyCompletedProcess{returncode: 1, stdout: '', stderr: 'No arguments'} }\n    mut p := os.new_process(args[0])\n    p.set_args(args[1..])\n    p.set_redirect_stdio()\n    p.run()\n    p.wait()\n    res := PyCompletedProcess{returncode: p.code, stdout: p.stdout_slurp(), stderr: p.stderr_slurp()}\n    p.close()\n    return res\n}")
 
              # py_subprocess_call(args []string) int
-             self.emitter.add_helper_function("fn py_subprocess_call(args []string) int {\n    cmd := args.join(' ')\n    return os.system(cmd)\n}")
+             self.emitter.add_helper_function("fn py_subprocess_call(args []string) int {\n    if args.len == 0 { return 1 }\n    mut p := os.new_process(args[0])\n    p.set_args(args[1..])\n    p.run()\n    p.wait()\n    code := p.code\n    p.close()\n    return code\n}")
 
         platform_used = "platform" in self.imported_modules.values()
         if not platform_used:

--- a/py2v_transpiler/tests/translator/test_subprocess_security.py
+++ b/py2v_transpiler/tests/translator/test_subprocess_security.py
@@ -1,0 +1,41 @@
+import ast
+import pytest
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def translate(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    if not isinstance(tree, ast.Module):
+        raise ValueError("Parsed AST is not a Module")
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+    helpers = translator.emitter.emit_helpers()
+    return v_code + "\n" + helpers
+
+def test_subprocess_security_run():
+    # Attempt injection in arguments
+    source = """
+import subprocess
+res = subprocess.run(["ls", "; rm -rf /"])
+"""
+    v_code = translate(source)
+    # After the fix, we expect os.new_process and set_args to be used
+    # and NO naive joining with spaces.
+    assert "os.new_process" in v_code
+    assert "set_args" in v_code
+    assert "args.join(' ')" not in v_code
+    assert "os.execute" not in v_code
+
+def test_subprocess_security_call():
+    source = """
+import subprocess
+ret = subprocess.call(["echo", "hello; whoami"])
+"""
+    v_code = translate(source)
+    assert "os.new_process" in v_code
+    assert "set_args" in v_code
+    assert "args.join(' ')" not in v_code
+    assert "os.system" not in v_code


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Command injection vulnerability in the transpiled V helper functions for Python's `subprocess.run` and `subprocess.call`.

### ⚠️ Risk: The potential impact if left unfixed
If left unfixed, an attacker could provide arguments containing shell metacharacters (like `;`, `&`, `|`) to `subprocess` functions in the source Python code. The transpiled V code would naively join these arguments with spaces and execute them via a shell, leading to arbitrary command execution on the system running the generated V program.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix replaces the use of `os.execute(cmd_string)` and `os.system(cmd_string)` with V's `os.new_process` API. 
1. Arguments are no longer joined into a single string. Instead, they are passed as an array to `p.set_args(args[1..])`.
2. This bypasses the shell entirely, ensuring that each argument is treated as a literal argument to the executable, regardless of any shell metacharacters it may contain.
3. The `py_subprocess_run` helper now correctly redirects and slurps both `stdout` and `stderr`, providing more accurate emulation of Python's `subprocess.CompletedProcess`.
4. Added validation to handle empty argument lists safely.

---
*PR created automatically by Jules for task [7079103928830447673](https://jules.google.com/task/7079103928830447673) started by @yaskhan*