### PR TITLE
Fix emitter output usage in test_todo_tasks.py

### DIFF
--- a/py2v_transpiler/tests/translator/test_todo_tasks.py
+++ b/py2v_transpiler/tests/translator/test_todo_tasks.py
@@ -10,9 +10,7 @@ class TestTodoTasks(unittest.TestCase):
 
     def transpile(self, source):
         tree = ast.parse(source)
-        self.translator.visit(tree)
-        # Fix: use emitter output, not internal buffer which is cleared
-        return self.translator.emitter.emit()
+        return self.translator.visit(tree)
 
     def test_metaclass(self):
         source = """


### PR DESCRIPTION
The transpile method in test_todo_tasks.py was redundant by calling both visit() and emitter.emit(). Since visit_Module already returns the result of emitter.emit(), the method was simplified to return the visit result directly.

---
*PR created automatically by Jules for task [12646698582112881056](https://jules.google.com/task/12646698582112881056) started by @yaskhan*