### PR TITLE
Feat: Add typing.assert_never translation

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -561,6 +561,11 @@ class CallsMixin(TranslatorBase):
                      return f"/* isinstance({obj}, {types}) - multi-type check not supported */ false"
                 return f"{obj} is {types}"
 
+        elif func_name_str == "assert_never":
+            if len(args) == 1:
+                return f"panic('assert_never reached: ${{{args[0]}}}')"
+            return "panic('assert_never reached')"
+
         elif func_name_str == "assert_type":
             if len(args) >= 2:
                 # Compile-time evaluation of assert_type

--- a/py2v_transpiler/tests/translator/test_typing_features.py
+++ b/py2v_transpiler/tests/translator/test_typing_features.py
@@ -160,6 +160,19 @@ class Proto(Protocol):
     assert "interface Proto {" in v_code
     assert "method(x int) int" in v_code
 
+def test_typing_assert_never():
+    source = """
+from typing import assert_never
+
+def check(x):
+    if x == 1:
+        pass
+    else:
+        assert_never(x)
+"""
+    v_code = translate(source)
+    assert "panic('assert_never reached: ${x}')" in v_code
+
 def test_typing_overload():
     source = """
 from typing import overload


### PR DESCRIPTION
This PR adds support for transpiling Python's `typing.assert_never()` calls into V's `panic()` calls. 

This accurately maintains the runtime behaviour of Python's exhaustiveness checker when translated, failing the execution path as an unexpected, unhandled condition via panic rather than silently succeeding. Tests have been successfully implemented to ensure the correct behaviour.

---
*PR created automatically by Jules for task [9461262769952178294](https://jules.google.com/task/9461262769952178294) started by @yaskhan*