### PR TITLE
add PEP 702: `@deprecated` Decorator

### DIFF
--- a/py2v_transpiler/core/decorators.py
+++ b/py2v_transpiler/core/decorators.py
@@ -16,6 +16,9 @@ class DecoratorInfo:
     injected_start: List[str] = field(default_factory=list)
     injected_end: List[str] = field(default_factory=list)
     implementation_name: Optional[str] = None
+    # PEP 702: @deprecated decorator support
+    deprecated: bool = False
+    deprecated_message: Optional[str] = None
 
 class DecoratorProcessor:
     def __init__(self, visitor: Any):
@@ -53,6 +56,15 @@ class DecoratorProcessor:
                 info.injected_start.append(f"println('Start {node.name}...')")
                 # Using defer for end logging is idiomatic in V
                 info.injected_end.append(f"defer {{ println('End {node.name}...') }}")
+                info.decorators_to_handle.append(dec_name)
+            elif dec_name == "deprecated":
+                # PEP 702: @warnings.deprecated decorator
+                info.deprecated = True
+                # Extract the message from the decorator call
+                if isinstance(decorator, ast.Call) and decorator.args:
+                    msg_arg = decorator.args[0]
+                    if isinstance(msg_arg, ast.Constant) and isinstance(msg_arg.value, str):
+                        info.deprecated_message = msg_arg.value
                 info.decorators_to_handle.append(dec_name)
             else:
                 # Custom or unknown -> emit as comment in visitor

--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -37,6 +37,9 @@ class ClassesMixin(TranslatorBase):
         # Handle decorators
         decorators = []
         is_dataclass = False
+        deprecated_message: Optional[str] = None
+        is_deprecated = False
+        
         for decorator in node.decorator_list:
             if isinstance(decorator, ast.Call):
                  # Decorator with args: @dec(arg)
@@ -48,8 +51,18 @@ class ClassesMixin(TranslatorBase):
                      val = self.visit(kw.value)
                      dec_args_list.append(f"{kw.arg}={val}")
                  dec_str = f"{func}({', '.join(dec_args_list)})"
+                 
+                 # Check for @deprecated("message")
+                 if func == "deprecated" and dec_args_list:
+                     is_deprecated = True
+                     # Extract message from first positional argument
+                     msg = dec_args_list[0].strip("'\"")
+                     deprecated_message = msg
             else:
                  dec_str = self.visit(decorator)
+                 # Check for @deprecated without args (rare but possible)
+                 if dec_str == "deprecated":
+                     is_deprecated = True
 
             decorators.append(f"// @{dec_str}")
             if dec_str.startswith("dataclass") or dec_str.startswith("dataclasses.dataclass"):
@@ -476,6 +489,14 @@ class ClassesMixin(TranslatorBase):
             struct_def = ""
             if doc_comment:
                 struct_def += doc_comment
+            
+            # PEP 702: Add [deprecated] attribute for @warnings.deprecated decorator
+            if is_deprecated:
+                if deprecated_message:
+                    struct_def += f"[deprecated: '{deprecated_message}']\n"
+                else:
+                    struct_def += "[deprecated]\n"
+            
             if decorators:
                 struct_def += "\n".join(decorators) + "\n"
 

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -361,10 +361,18 @@ class FunctionsMixin(TranslatorBase):
 
         noreturn_attr = "[noreturn]\n" if is_noreturn else ""
 
+        # PEP 702: Add [deprecated] attribute for @warnings.deprecated decorator
+        deprecated_attr = ""
+        if dec_info.deprecated:
+            if dec_info.deprecated_message:
+                deprecated_attr = f"[deprecated: '{dec_info.deprecated_message}']\n"
+            else:
+                deprecated_attr = "[deprecated]\n"
+
         if 'decl' not in locals():
-            decl = f"{noreturn_attr}fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
+            decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
         if ret_type == "void":
-             decl = f"{noreturn_attr}fn {receiver_str}{func_name}({args_str}) {{"
+             decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {{"
 
         self.output.append(f"{decl}")
         self._indent_level += 1

--- a/py2v_transpiler/tests/translator/test_decorators.py
+++ b/py2v_transpiler/tests/translator/test_decorators.py
@@ -116,3 +116,70 @@ class MyClass:
     # Treated as static method (no receiver)
     # The argument 'cls' is present. Type defaults to int.
     assert "fn factory(cls int)" in code, f"Code:\n{code}"
+
+def test_deprecated_function():
+    """Test PEP 702 @deprecated decorator on function"""
+    source = """
+from warnings import deprecated
+
+@deprecated("Use new_func instead")
+def old_func():
+    pass
+"""
+    visitor = VNodeVisitor(TypeInference())
+    tree = ast.parse(source)
+    code = visitor.visit(tree)
+
+    # Check for [deprecated] attribute with message
+    assert "[deprecated: 'Use new_func instead']" in code, f"Code:\n{code}"
+    assert "fn old_func() {" in code, f"Code:\n{code}"
+
+def test_deprecated_function_no_message():
+    """Test @deprecated decorator without message"""
+    source = """
+@deprecated
+def old_func():
+    pass
+"""
+    visitor = VNodeVisitor(TypeInference())
+    tree = ast.parse(source)
+    code = visitor.visit(tree)
+
+    # Check for [deprecated] attribute without message
+    assert "[deprecated]" in code, f"Code:\n{code}"
+    assert "[deprecated: '" not in code, f"Code:\n{code}"
+
+def test_deprecated_class():
+    """Test PEP 702 @deprecated decorator on class"""
+    source = """
+from warnings import deprecated
+
+@deprecated("Use NewClass instead")
+class OldClass:
+    pass
+"""
+    visitor = VNodeVisitor(TypeInference())
+    tree = ast.parse(source)
+    code = visitor.visit(tree)
+
+    # Check for [deprecated] attribute on struct
+    assert "[deprecated: 'Use NewClass instead']" in code, f"Code:\n{code}"
+    assert "struct OldClass {" in code, f"Code:\n{code}"
+
+def test_deprecated_method():
+    """Test @deprecated decorator on method"""
+    source = """
+from warnings import deprecated
+
+class MyClass:
+    @deprecated("Use new_method instead")
+    def old_method(self):
+        pass
+"""
+    visitor = VNodeVisitor(TypeInference())
+    tree = ast.parse(source)
+    code = visitor.visit(tree)
+
+    # Check for [deprecated] attribute on method
+    assert "[deprecated: 'Use new_method instead']" in code, f"Code:\n{code}"
+    assert "fn (self MyClass) old_method() {" in code, f"Code:\n{code}"

--- a/todo2.md
+++ b/todo2.md
@@ -19,7 +19,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
   - Differentiate from `TypeGuard`: `TypeIs` narrows in the `else`-branch (to the negation). Implement handling for both branches.
 - [ ] **PEP 696: Type Variable Defaults**
   - Support new Python 3.13 syntax for generic defaults: `class Box[T = int]: ...`
-- [ ] **PEP 702: `@deprecated` Decorator**
+- [x] **PEP 702: `@deprecated` Decorator**
   - Transpile `warnings.deprecated` to V's `[deprecated]` attribute on functions/structs.
 - [ ] **Property Setters and Getters with Different Types**
   - Ensure the translator can handle and correctly emit V code when a `@property` and its `@foo.setter` have slightly mismatched type hints (e.g., returning `int` but accepting `str | int`).


### PR DESCRIPTION
Transpile `warnings.deprecated` to V's `[deprecated]` attribute on functions/structs.