### PR TITLE
Map StringIO and IO[str] to V strings.Builder

### DIFF
--- a/py2v_transpiler/models/v_types.py
+++ b/py2v_transpiler/models/v_types.py
@@ -86,6 +86,11 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Fa
                 return f"map[{mapped_args[0]}]{mapped_args[1]}"
             return "map[string]int" # fallback
 
+        elif value_id in ('IO', 'TextIO'):
+            if len(mapped_args) >= 1 and mapped_args[0] == 'string':
+                return "&strings.Builder"
+            return "os.File"
+
         elif value_id == 'Tuple':
             # Tuple[int, ...] -> []int
             if len(mapped_args) == 2 and mapped_args[1] == '...':
@@ -197,6 +202,9 @@ def _map_basic_type(name: str) -> str:
         'IO': 'os.File',
         'TextIO': 'os.File',
         'BinaryIO': 'os.File',
+        'StringIO': 'strings.Builder',
+        'io.StringIO': 'strings.Builder',
+        'six.moves.StringIO': 'strings.Builder',
         'NoReturn': 'void',
         'builtins.int': 'int',
         'builtins.float': 'f64',

--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -51,6 +51,12 @@ class StdLibMapper:
                 "argv": "os.args",
                 "platform": "os.user_os()", # Approximation
             },
+            "io": {
+                "StringIO": self._io_stringio,
+            },
+            "six.moves": {
+                "StringIO": self._io_stringio,
+            },
             "os": {
                 "environ": "os.environ()",
                 "getcwd": "os.getwd",
@@ -253,6 +259,8 @@ class StdLibMapper:
             "time": ["time"],
             "datetime": ["time"],
             "sys": ["os"],
+            "io": ["strings"],
+            "six.moves": ["strings"],
             "os": ["os"],
             "re": ["regex"],
             "shutil": ["os"],
@@ -342,6 +350,11 @@ class StdLibMapper:
         return self.v_imports.get(module)
 
     # specialized handlers
+
+    def _io_stringio(self, args: List[str]) -> str:
+        if len(args) == 0:
+            return "strings.new_builder(1024)"
+        return f"py_io_stringio({args[0]})"
 
     def _random_randint(self, args: List[str]) -> str:
         if len(args) == 2:

--- a/todo2.md
+++ b/todo2.md
@@ -408,7 +408,7 @@ Based on the transpilation of the `bm_hexiom.py` benchmark, several critical are
   - *Context:* `LEVELS[2] = ...` assignments are placed inside the generated `fn main()`, trapping the global state in a local scope.
   - *Task:* Ensure that module-level collection mutations (like dict assignments) are placed in a V `fn init()` block or a `__global` initialization routine so that global constants are properly populated and accessible to other functions.
 
-- [ ] **`StringIO` and `IO` Type Mappings**
+- [x] **`StringIO` and `IO` Type Mappings**
   - *Context:* `bm_hexiom.py` uses `StringIO` for stream output, which maps directly to undefined `StringIO` and `IO[string]` types in V.
   - *Task:* Map `io.StringIO` (and `six.moves.StringIO`) to V's `strings.Builder`. Map `IO[str]` to `&strings.Builder` or an appropriate stream interface in V.
 


### PR DESCRIPTION
Closes task from todo2.md:
- Map `StringIO`, `io.StringIO`, and `six.moves.StringIO` to `strings.Builder`.
- Map `IO[str]` and `TextIO[str]` to `&strings.Builder`.
- Provide initialization default `strings.new_builder(1024)`.
- Mark task as completed in `todo2.md`.