### PR TITLE
feat: add support for PEP 800 disjoint_base decorator

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -38,6 +38,7 @@ class ClassesMixin(TranslatorBase):
         decorators = []
         is_dataclass = False
         is_deprecated = False
+        is_disjoint_base = False
         deprecated_message: Optional[str] = None
         
         for decorator in node.decorator_list:
@@ -63,6 +64,8 @@ class ClassesMixin(TranslatorBase):
                  # Check for @deprecated without args (rare but possible)
                  if dec_str == "deprecated":
                      is_deprecated = True
+                 elif dec_str in ("disjoint_base", "typing.disjoint_base"):
+                     is_disjoint_base = True
 
             decorators.append(f"// @{dec_str}")
             if dec_str.startswith("dataclass") or dec_str.startswith("dataclasses.dataclass"):
@@ -522,6 +525,9 @@ class ClassesMixin(TranslatorBase):
                     struct_def += f"[deprecated: '{deprecated_message}']\n"
                 else:
                     struct_def += "[deprecated]\n"
+
+            if is_disjoint_base:
+                struct_def += "[disjoint_base]\n"
 
             if decorators:
                 struct_def += "\n".join(decorators) + "\n"

--- a/py2v_transpiler/tests/translator/test_disjoint_base.py
+++ b/py2v_transpiler/tests/translator/test_disjoint_base.py
@@ -1,0 +1,26 @@
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def translate(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    if not isinstance(tree, ast.Module):
+        raise ValueError("Parsed AST is not a Module")
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+    helpers = translator.emitter.emit_helpers()
+    return v_code + "\n" + helpers
+
+def test_disjoint_base():
+    source = """
+from typing import disjoint_base
+
+@disjoint_base
+class Provider:
+    pass
+"""
+    v_code = translate(source)
+    assert "Provider" in v_code

--- a/py2v_transpiler/tests/translator/test_typing_features.py
+++ b/py2v_transpiler/tests/translator/test_typing_features.py
@@ -209,3 +209,20 @@ def check(x: int) -> None:
     v_code = translate(source)
     # assert_never should be translated to a panic or similar
     assert "panic" in v_code.lower() or "assert_never" in v_code
+
+def test_typing_disjoint_base():
+    source = """
+from typing import disjoint_base
+
+@disjoint_base
+class BaseClass:
+    pass
+
+@disjoint_base
+class AnotherBase:
+    pass
+"""
+    v_code = translate(source)
+    assert "[disjoint_base]" in v_code
+    assert "struct BaseClass {" in v_code
+    assert "struct AnotherBase {" in v_code

--- a/todo2.md
+++ b/todo2.md
@@ -10,7 +10,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
   - Parse `TypeForm[T]` in argument and return annotations.
   - *V Translation:* Since V lacks type reification, generate overloaded functions or use `Any` with runtime checks (optionally behind an `--experimental` flag).
   - Use `--enable-incomplete-feature=TypeForm` when running mypy for validation.
-- [ ] **PEP 800: Disjoint Base Classes (`@disjoint_base`)**
+- [x] **PEP 800: Disjoint Base Classes (`@disjoint_base`)**
   - Add support for detecting `@disjoint_base` decorator.
 - [ ] **PEP 742: TypeIs (mypy 1.10+)**
   - *Context:* Improved type guard that narrows the type in both branches of a condition.


### PR DESCRIPTION
This PR adds support for translating the PEP 800 `@disjoint_base` (or `@typing.disjoint_base`) decorator. When a Python class is decorated with `@disjoint_base`, the generated V struct will include the `[disjoint_base]` attribute. Tests have been added to verify this behavior and the corresponding task in `todo2.md` is marked as complete.

---
*PR created automatically by Jules for task [17936960586117973890](https://jules.google.com/task/17936960586117973890) started by @yaskhan*