### PR TITLE
feat: Support PEP 696 Type Variable Defaults

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -34,6 +34,17 @@ class ClassesMixin(TranslatorBase):
         self.current_class_bases = []
         self.current_class_is_unittest = False
 
+        if hasattr(node, 'type_params') and node.type_params:
+            for param in node.type_params:
+                # TypeVar, ParamSpec, TypeVarTuple might have 'name' as string or attribute
+                # PEP 696 type defaults (param.default) are intentionally ignored since V doesn't support them
+                if hasattr(param, 'name'):
+                    name = param.name
+                    if isinstance(name, str):
+                        self.current_class_generics.append(name)
+                    elif hasattr(name, 'id'):
+                        self.current_class_generics.append(name.id)
+
         # Handle decorators
         decorators = []
         is_dataclass = False

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -189,6 +189,23 @@ class FunctionsMixin(TranslatorBase):
                  self.output.append(f"// {node.name} method in unittest class ignored")
                  return
 
+        # Handle Python 3.12+ type_params (e.g. def foo[T](x: T):)
+        func_generics_str = ""
+        # Only add generics to the function itself if it's not a method of a generic struct
+        # because V methods inherit generics from the struct receiver `(s Struct[T]) method()`.
+        if not is_method and hasattr(node, 'type_params') and node.type_params:
+            func_generics = []
+            for param in node.type_params:
+                # PEP 696 type defaults (param.default) are intentionally ignored since V doesn't support them
+                if hasattr(param, 'name'):
+                    name = param.name
+                    if isinstance(name, str):
+                        func_generics.append(name)
+                    elif hasattr(name, 'id'):
+                        func_generics.append(name.id)
+            if func_generics:
+                func_generics_str = f"[{', '.join(func_generics)}]"
+
         if is_generator:
             # Inject channel argument
             yield_type = self.coroutine_handler.get_yield_type(node)
@@ -415,9 +432,9 @@ class FunctionsMixin(TranslatorBase):
                 deprecated_attr = "[deprecated]\n"
 
         if 'decl' not in locals():
-            decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
+            decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}{func_generics_str}({args_str}) {ret_type} {{"
         if ret_type == "void":
-             decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {{"
+             decl = f"{noreturn_attr}{deprecated_attr}fn {receiver_str}{func_name}{func_generics_str}({args_str}) {{"
 
         self.output.append(f"{decl}")
         self._indent_level += 1
@@ -473,6 +490,21 @@ class FunctionsMixin(TranslatorBase):
 
     def _generate_overload_variants(self, node: Any, struct_name: str, is_method: bool, dec_info: Any, is_generator: bool) -> None:
         """Generates V functions for each @overload signature using the implementation body."""
+
+        func_generics_str = ""
+        if not is_method and hasattr(node, 'type_params') and node.type_params:
+            func_generics = []
+            for param in node.type_params:
+                # PEP 696 type defaults (param.default) are intentionally ignored since V doesn't support them
+                if hasattr(param, 'name'):
+                    name = param.name
+                    if isinstance(name, str):
+                        func_generics.append(name)
+                    elif hasattr(name, 'id'):
+                        func_generics.append(name.id)
+            if func_generics:
+                func_generics_str = f"[{', '.join(func_generics)}]"
+
         # Check for @warnings.deprecated
         is_deprecated = False
         deprecated_message: str | None = None
@@ -559,9 +591,9 @@ class FunctionsMixin(TranslatorBase):
             if is_operator:
                 decl = f"{deprecated_attr}fn {receiver_str}{op_str} ({args_str}) {ret_type} {{"
             else:
-                decl = f"{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {ret_type} {{"
+                decl = f"{deprecated_attr}fn {receiver_str}{func_name}{func_generics_str}({args_str}) {ret_type} {{"
                 if ret_type == "void":
-                    decl = f"{deprecated_attr}fn {receiver_str}{func_name}({args_str}) {{"
+                    decl = f"{deprecated_attr}fn {receiver_str}{func_name}{func_generics_str}({args_str}) {{"
 
             self.output.append(decl)
             self._indent_level += 1

--- a/py2v_transpiler/core/translator/variables.py
+++ b/py2v_transpiler/core/translator/variables.py
@@ -721,7 +721,14 @@ class VariablesMixin(TranslatorBase):
             # Handle generics [T, U]
             params = []
             for param in node.type_params:
-                if isinstance(param, TypeVar):
+                # PEP 696 type defaults (param.default) are intentionally ignored since V doesn't support them
+                if hasattr(param, 'name'):
+                    name_attr = param.name
+                    if isinstance(name_attr, str):
+                        params.append(name_attr)
+                    elif hasattr(name_attr, 'id'):
+                        params.append(name_attr.id)
+                elif isinstance(param, TypeVar):
                     params.append(param.name)
                 # Basic support for TypeVar only for now
             if params:

--- a/todo2.md
+++ b/todo2.md
@@ -17,7 +17,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
   - Recognize functions returning `TypeIs[T]` instead of `bool`.
   - *V Translation:* Generate an `if` with an automatic type cast inside the block (using narrowing info from mypy).
   - Differentiate from `TypeGuard`: `TypeIs` narrows in the `else`-branch (to the negation). Implement handling for both branches.
-- [ ] **PEP 696: Type Variable Defaults**
+- [x] **PEP 696: Type Variable Defaults**
   - Support new Python 3.13 syntax for generic defaults: `class Box[T = int]: ...`
 - [x] **PEP 702: `@deprecated` Decorator**
   - Transpile `warnings.deprecated` to V's `[deprecated]` attribute on functions/structs.
@@ -187,7 +187,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
 - [ ] **PEP 695: Full type parameter syntax**
   - Support syntax like `def func[T](x: T) -> T: ...`, `class Box[T]: value: T`, `type Alias[T] = list[T]`.
   - Handle new AST nodes: `TypeVar`, `ParamSpec`, `TypeVarTuple`, `type_params` list.
-- [ ] **PEP 696: Type parameter defaults (Python 3.13+)**
+- [x] **PEP 696: Type parameter defaults (Python 3.13+)**
   - Support generic defaults: `def foo[T = int](x: T): ...` or `class Container[T = list[int]]: ...`.
 - [ ] **PEP 750: Template string literals (`t-strings`)**
   - Support `t"Hello {name=}"`, `T"Value: {value!r}"` by mapping the returned `Template` object to a custom string builder or interpolation mechanism in V.


### PR DESCRIPTION
This PR implements support for PEP 696 (Type Variable Defaults) introduced in Python 3.13.

Vlang does not natively support default types in generics (`[T = int]`), so the transpiler is updated to correctly parse the new Python 3.12+ `type_params` syntax while actively bypassing the `.default` assignment to prevent transpilation crashes. 

The changes correctly map:
- `class Box[T = int]: ...` -> `struct Box[T] {`
- `def foo[T = int](x: T): ...` -> `fn foo[T](x T) {`
- `type Alias[T = int] = list[T]` -> `type Alias[T] = []T`

---
*PR created automatically by Jules for task [15318165908271832811](https://jules.google.com/task/15318165908271832811) started by @yaskhan*