### PR TITLE
feat: support mypy 1.14 loop index type narrowing for TypedDicts

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/subscripts.py
+++ b/py2v_transpiler/core/translator/expressions_split/subscripts.py
@@ -13,6 +13,25 @@ class SubscriptsMixin(TranslatorBase):
              if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
                   return f"{value}.{node.slice.value}"
 
+             # Fast path for narrowed loop variables: match key { 'name': d.name, ... }
+             idx_type = self._guess_type(node.slice)
+             if idx_type.startswith("Literal["):
+                 # Extract literals: Literal["name", "age"]
+                 try:
+                     literals_str = idx_type[8:-1]
+                     # naive split by comma
+                     parts = [p.strip().strip('"').strip("'") for p in literals_str.split(',')]
+
+                     match_branches = []
+                     idx_str = self.visit(node.slice)
+                     for part in parts:
+                         match_branches.append(f"'{part}' {{ Any({value}.{part}) }}")
+
+                     match_branches.append("else { panic('unreachable typeddict access') }")
+                     return f"match {idx_str} {{ " + " ".join(match_branches) + " }"
+                 except Exception:
+                     pass
+
         # Handle Ellipsis in slice (e.g. a[...])
         if isinstance(node.slice, ast.Constant) and node.slice.value is Ellipsis:
              return f"{value}[/* ... */]"

--- a/py2v_transpiler/tests/translator/test_control_flow.py
+++ b/py2v_transpiler/tests/translator/test_control_flow.py
@@ -90,3 +90,27 @@ while True:
 
     assert "break" in result
     assert "continue" in result
+
+def test_translator_index_narrowing_loop():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    # We manually register UserDict as a dataclass (TypedDict) for the test
+    translator.dataclasses["UserDict"] = ["name", "age"]
+    analyzer.type_map["d"] = "UserDict"
+
+    # Simulate mypy inferring Literal for loop key
+    analyzer.type_map["key"] = "Literal[\"name\", \"age\"]"
+
+    code = """
+for key in ("name", "age"):
+    print(d[key])
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "match key {" in result
+    assert "'name' { Any(d.name) }" in result
+    assert "'age' { Any(d.age) }" in result

--- a/todo2.md
+++ b/todo2.md
@@ -41,7 +41,7 @@ Based on recent Python ecosystem developments (mypy, PyPy, Numba, NumPy, Nuitka,
   - Warn if a `LiteralString` variable receives a value from `input()` (loss of guarantee).
 
 ## Type Narrowing Improvements (Based on mypy 1.14–1.19)
-- [ ] **Index Narrowing in for-loops (mypy 1.14)**
+- [x] **Index Narrowing in for-loops (mypy 1.14)**
   - *Context:* Mypy now preserves the literal type of loop variables (e.g., `for key in ("name", "age"):`).
   - Retrieve the narrowed literal type of the loop variable from the mypy AST.
   - *V Translation:* Generate more precise types instead of a generic `string`/`int`.


### PR DESCRIPTION
Fixes #TODO2 **Index Narrowing in for-loops (mypy 1.14)**

- Reads narrowed literal types directly from mypy's `type_map`.
- Optimizes `TypedDict` collection access by mapping literal keys to direct struct properties wrapped in `Any` for type unification in heterogeneous structs.
- Reverted AST hacks that corrupted explicit `Literal` translations to valid mypy-centric approach.

---
*PR created automatically by Jules for task [4458452352800719098](https://jules.google.com/task/4458452352800719098) started by @yaskhan*