### PR TITLE
Fix incorrect Vlang syntax for primitive type casting

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -357,6 +357,7 @@ class TranslatorBase(ast.NodeVisitor):
                 if fid == "float": return "f64"
                 if fid == "bool": return "bool"
                 if fid == "len": return "int"
+                if fid == "input": return "string"
 
         return "int"
 

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -442,6 +442,42 @@ class CallsMixin(TranslatorBase):
                 return f"panic('assert_never reached: ${{args[0]}}')"
             return "// assert_never requires 1 argument"
 
+        # Handle primitive type "casting" or conversions (priority over class instantiation)
+        if func_name_str == "int" or (original_id == "int" and func_name_str == "py_int"):
+            if len(args) == 0:
+                return "0"
+            elif len(args) == 1:
+                arg_type = self._guess_type(node.args[0])
+                if arg_type == "string":
+                    return f"{args[0]}.int()"
+                return f"int({args[0]})"
+            elif len(args) == 2:
+                # E.g. int('ff', 16) - V has strconv.parse_int
+                self.emitter.add_import("strconv")
+                return f"int(strconv.parse_int({args[0]}, {args[1]}, 32) or {{ 0 }})"
+        elif func_name_str == "float" or (original_id == "float" and func_name_str == "py_float"):
+            if len(args) == 1:
+                arg_type = self._guess_type(node.args[0])
+                if arg_type == "string":
+                    return f"{args[0]}.f64()"
+                return f"f64({args[0]})"
+            return "0.0"
+        elif func_name_str == "bool" or (original_id == "bool" and func_name_str == "py_bool"):
+            if len(args) == 1:
+                arg_type = self._guess_type(node.args[0])
+                if arg_type == "int": return f"({args[0]} != 0)"
+                if arg_type == "string": return f"({args[0]} != '')"
+                if arg_type.startswith("[]"): return f"({args[0]}.len > 0)"
+                return f"py_bool({args[0]})"
+            return "false"
+        elif func_name_str == "str" or (original_id == "str" and func_name_str == "py_str"):
+            if len(args) == 1:
+                return f"{args[0]}.str()"
+            return "''"
+        elif func_name_str == "bytes":
+            if len(args) == 2:
+                return f"{args[0]}.bytes()"
+
         # Handle dataclass constructor call
         dataclass_metadata = None
         if call_sig and "dataclass_metadata" in call_sig:
@@ -571,27 +607,6 @@ class CallsMixin(TranslatorBase):
                 return f"math.round({args[0]})"
 
 
-        elif func_name_str == "float":
-            if len(args) == 1:
-                return f"f64({args[0]})"
-            return "0.0"
-
-        elif func_name_str == "bytes":
-            if len(args) == 2:
-                return f"{args[0]}.bytes()"
-        elif func_name_str == "int":
-            if len(args) == 0:
-                return "0"
-            elif len(args) == 1:
-                arg_type = self._guess_type(node.args[0])
-                if arg_type == "string":
-                    return f"{args[0]}.int()"
-                return f"int({args[0]})"
-            elif len(args) == 2:
-                # E.g. int('ff', 16) - V has strconv.parse_int
-                # but let's keep it simple or use strconv if required
-                self.emitter.add_import("strconv")
-                return f"int(strconv.parse_int({args[0]}, {args[1]}, 32) or {{ 0 }})"
 
         elif func_name_str == "isinstance":
             if len(args) == 2:

--- a/py2v_transpiler/tests/translator/test_dict_comp.py
+++ b/py2v_transpiler/tests/translator/test_dict_comp.py
@@ -23,13 +23,13 @@ def test_dict_comp_string_key():
     code = "d = {str(x): x for x in range(5)}"
     v_code = transpile(code)
     assert "map[string]int" in v_code
-    assert "d[str(x)] = x" in v_code
+    assert "d[x.str()] = x" in v_code
 
 def test_dict_comp_string_val():
     code = "d = {x: str(x) for x in range(5)}"
     v_code = transpile(code)
     assert "map[int]string" in v_code
-    assert "d[x] = str(x)" in v_code
+    assert "d[x] = x.str()" in v_code
 
 def test_dict_comp_zip():
     code = "d = {k: v for k, v in zip(['a', 'b'], [1, 2])}"

--- a/py2v_transpiler/tests/translator/test_int_casting_bug.py
+++ b/py2v_transpiler/tests/translator/test_int_casting_bug.py
@@ -1,0 +1,29 @@
+from py2v_transpiler.tests.translator.utils import TranspilerTest
+
+class TestIntCastingBug(TranspilerTest):
+    def test_int_input_casting(self):
+        # This currently fails by producing 'number := int{os.input('Prompt: ')}'
+        # if the analyzer somehow thinks 'int' is a class (which it is in Python).
+        # We want it to be 'number := os.input('Prompt: ').int()' or 'int(os.input(...))'
+        self.assert_transpilation(
+            "number = int(input('Prompt: '))",
+            "number := os.input('Prompt: ').int()"
+        )
+
+    def test_float_casting(self):
+        self.assert_transpilation(
+            "val = float('3.14')",
+            "val := '3.14'.f64()"
+        )
+
+    def test_bool_casting(self):
+        self.assert_transpilation(
+            "val = bool(1)",
+            "val := (1 != 0)"
+        )
+
+    def test_str_casting(self):
+        self.assert_transpilation(
+            "val = str(42)",
+            "val := 42.str()"
+        )

--- a/py2v_transpiler/tests/translator/test_uuid.py
+++ b/py2v_transpiler/tests/translator/test_uuid.py
@@ -30,4 +30,4 @@ import uuid
 u = str(uuid.uuid4())
 """
     v_code = translate(source)
-    assert "u := str(rand.uuid_v4())" in v_code # V's uuid_v4 returns string usually, so str() might be redundant but valid.
+    assert "u := rand.uuid_v4().str()" in v_code # V's uuid_v4 returns string usually, so .str() might be redundant but valid.


### PR DESCRIPTION
This change fixes a bug where Python's primitive type casting (int, float, etc.) was incorrectly translated to Vlang struct initialization syntax when the analyzer identified them as classes. It moves primitive handling to the top of Call handling and ensures idiomatic Vlang code generation (e.g., using .int(), .f64(), .str() for string conversions). Additionally, it updates the type inference to correctly identify the return type of input() as a string.

Fixes #146

---
*PR created automatically by Jules for task [1411204140970876454](https://jules.google.com/task/1411204140970876454) started by @yaskhan*