### PR TITLE
Translate Python elif to Vlang else if

### DIFF
--- a/py2v_transpiler/core/translator/control_flow_split/conditionals.py
+++ b/py2v_transpiler/core/translator/control_flow_split/conditionals.py
@@ -3,31 +3,48 @@ from ..base import TranslatorBase
 
 class ConditionalsMixin(TranslatorBase):
     """Обработка условных операторов: if, elif, else"""
-    
-    def visit_If(self, node: ast.If) -> None:
-        # Check for if __name__ == "__main__":
+
+    def _is_name_main(self, node: ast.If) -> bool:
+        """Checks for if __name__ == "__main__":"""
         if isinstance(node.test, ast.Compare):
             if (isinstance(node.test.left, ast.Name) and node.test.left.id == "__name__" and
                 len(node.test.comparators) == 1 and isinstance(node.test.comparators[0], ast.Constant) and
                 node.test.comparators[0].value == "__main__"):
+                return True
+        return False
+
+    def _has_walrus(self, node: ast.AST) -> bool:
+        """Checks if an expression contains a walrus operator."""
+        for child in ast.walk(node):
+            if isinstance(child, ast.NamedExpr):
+                return True
+        return False
+
+    def visit_If(self, node: ast.If) -> None:
+        self._visit_if(node, is_elif=False)
+
+    def _visit_if(self, node: ast.If, is_elif: bool = False) -> None:
+        if not is_elif:
+            # Check for if __name__ == "__main__":
+            if self._is_name_main(node):
                 self.output.append(f"{self._indent()}// if __name__ == '__main__':")
                 for stmt in node.body:
                     self.visit(stmt)
                 return
 
-        if_vars = self._collect_assigned_vars(node.body)
-        else_vars = self._collect_assigned_vars(node.orelse) if node.orelse else set()
+            if_vars = self._collect_assigned_vars(node.body)
+            else_vars = self._collect_assigned_vars(node.orelse) if node.orelse else set()
 
-        # Pre-declare conditionally initialized variables
-        for var in (if_vars | else_vars):
-            if not self.in_main and var not in self._local_vars_in_scope:
-                v_type = self._guess_type(ast.Name(id=var, ctx=ast.Store()))
-                if v_type == "unknown":
-                    v_type = "Any"
-                if not v_type.startswith("?"):
-                    v_type = f"?{v_type}"
-                self.output.append(f"{self._indent()}mut {var} := {v_type}(none)")
-                self._local_vars_in_scope.add(var)
+            # Pre-declare conditionally initialized variables
+            for var in (if_vars | else_vars):
+                if not self.in_main and var not in self._local_vars_in_scope:
+                    v_type = self._guess_type(ast.Name(id=var, ctx=ast.Store()))
+                    if v_type == "unknown":
+                        v_type = "Any"
+                    if not v_type.startswith("?"):
+                        v_type = f"?{v_type}"
+                    self.output.append(f"{self._indent()}mut {var} := {v_type}(none)")
+                    self._local_vars_in_scope.add(var)
 
         # Check for TypeGuard / TypeIs narrowing
         narrow_if = None
@@ -129,7 +146,12 @@ class ConditionalsMixin(TranslatorBase):
                  self.output.append(f"{self._indent()}{assign}")
              self._walrus_assignments = []
 
-        self.output.append(f"{self._indent()}if {test_expr} {{")
+        if is_elif:
+            last_line = self.output.pop()
+            self.output.append(f"{last_line}if {test_expr} {{")
+        else:
+            self.output.append(f"{self._indent()}if {test_expr} {{")
+
         self._indent_level += 1
 
         if narrow_if:
@@ -140,15 +162,12 @@ class ConditionalsMixin(TranslatorBase):
         self._indent_level -= 1
 
         if node.orelse:
-            if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
-                # elif case
-                self.output.append(f"{self._indent()}}} else {{")
-                self._indent_level += 1
-                if narrow_else:
-                    self.output.append(f"{self._indent()}{narrow_else}")
-                self.visit(node.orelse[0])
-                self._indent_level -= 1
-                self.output.append(f"{self._indent()}}}")
+            if (len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If) and
+                not narrow_else and not self._is_name_main(node.orelse[0]) and
+                not self._has_walrus(node.orelse[0].test)):
+                # Optimized elif case: else if
+                self.output.append(f"{self._indent()}}} else ")
+                self._visit_if(node.orelse[0], is_elif=True)
             else:
                 self.output.append(f"{self._indent()}}} else {{")
                 self._indent_level += 1

--- a/py2v_transpiler/tests/translator/test_elif.py
+++ b/py2v_transpiler/tests/translator/test_elif.py
@@ -1,0 +1,34 @@
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+def test_translator_elif():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+number = 15
+if number > 10:
+    print("A")
+elif number > 5:
+    print("B")
+elif number > 2:
+    print("C")
+else:
+    print("D")
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    print(result)
+
+    # Current output would have nested else { if ... }
+    # We want to check if it contains "else if"
+    assert "else if number > 5 {" in result
+    assert "else if number > 2 {" in result
+    assert "else {" in result
+
+if __name__ == "__main__":
+    test_translator_elif()


### PR DESCRIPTION
The transpiler now generates idiomatic Vlang 'else if' statements for Python 'elif', significantly improving code readability.

Key changes:
- Refactored `visit_If` into a recursive `_visit_if` that supports an `is_elif` flag.
- Added logic to detect and use the `else if` syntax when the `orelse` block contains a single `if` statement.
- Implemented safety checks to preserve nesting in cases where Vlang requires a separate block scope, such as:
    - When the condition contains a walrus operator (ensuring assignments happen before the check).
    - When the previous branch results in `TypeIs` narrowing that requires a specific `else` block for the negated type cast.
    - When encountering the special `if __name__ == '__main__':` block.
- Updated variable pre-declaration logic to scan the entire `if-elif-else` chain once at the top level, ensuring all conditionally assigned variables are properly initialized as mutable optionals in Vlang.
- Added a new test `py2v_transpiler/tests/translator/test_elif.py` and verified all existing tests pass.

Fixes #148

---
*PR created automatically by Jules for task [7848771564760439007](https://jules.google.com/task/7848771564760439007) started by @yaskhan*