### PR TITLE
Fix String Iteration and bytes() Encoding

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -334,6 +334,14 @@ class TranslatorBase(ast.NodeVisitor):
                 if hasattr(self.type_inference, "type_map") and attr_name in self.type_inference.type_map:
                     return self.type_inference.type_map[attr_name]
             return "Any"
+        elif isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Attribute) and isinstance(node.value.value, ast.Name):
+                if node.value.value.id == "sys" and node.value.attr == "argv":
+                    return "string"
+            elif isinstance(node.value, ast.Name):
+                if node.value.id == "argv": # Common if from sys import argv
+                    return "string"
+            return "Any"
         elif isinstance(node, ast.BinOp):
             left = self._guess_type(node.left)
             right = self._guess_type(node.right)

--- a/py2v_transpiler/core/translator/control_flow_split/loops.py
+++ b/py2v_transpiler/core/translator/control_flow_split/loops.py
@@ -251,9 +251,13 @@ class LoopsMixin(TranslatorBase):
         is_dict_items = isinstance(node.iter, ast.Call) and isinstance(node.iter.func, ast.Attribute) and node.iter.func.attr == "items"
 
         is_string_iter = False
-        if isinstance(node.iter, ast.Call) and getattr(node.iter.func, 'id', '') == "str":
+        iter_to_check = node.iter
+        if is_enumerate and isinstance(node.iter, ast.Call) and node.iter.args:
+            iter_to_check = node.iter.args[0]
+
+        if isinstance(iter_to_check, ast.Call) and getattr(iter_to_check.func, 'id', '') == "str":
             is_string_iter = True
-        elif hasattr(self, '_guess_type') and self._guess_type(node.iter) == "string":
+        elif hasattr(self, '_guess_type') and self._guess_type(iter_to_check) == "string":
             is_string_iter = True
 
         # 1. Обработка деструктуризации кортежа (кроме случаев с enumerate/dict.items)
@@ -286,9 +290,17 @@ class LoopsMixin(TranslatorBase):
 
         # 3. Генерация основного цикла (с учетом специфики строк в V)
         if is_string_iter:
-            self.output.append(f"{self._indent()}for {target}_u8 in {iter_expr} {{")
-            self._indent_level += 1
-            self.output.append(f"{self._indent()}{target} := {target}_u8.ascii_str()")
+            if is_enumerate and "," in target:
+                parts = [p.strip() for p in target.split(",")]
+                idx_var = parts[0]
+                val_var = parts[1]
+                self.output.append(f"{self._indent()}for {idx_var}, {val_var}_u8 in {iter_expr} {{")
+                self._indent_level += 1
+                self.output.append(f"{self._indent()}{val_var} := {val_var}_u8.ascii_str()")
+            else:
+                self.output.append(f"{self._indent()}for {target}_u8 in {iter_expr} {{")
+                self._indent_level += 1
+                self.output.append(f"{self._indent()}{target} := {target}_u8.ascii_str()")
         else:
             self.output.append(f"{self._indent()}for {target} in {iter_expr} {{")
             self._indent_level += 1

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -475,7 +475,8 @@ class CallsMixin(TranslatorBase):
                 return f"{args[0]}.str()"
             return "''"
         elif func_name_str == "bytes":
-            if len(args) == 2:
+            # Handle bytes(msg, "utf8") or bytes(msg, encoding="utf8")
+            if len(args) >= 1:
                 return f"{args[0]}.bytes()"
 
         # Handle dataclass constructor call

--- a/py2v_transpiler/tests/translator/test_string_bytes_fixes.py
+++ b/py2v_transpiler/tests/translator/test_string_bytes_fixes.py
@@ -1,0 +1,60 @@
+import unittest
+from py2v_transpiler.tests.translator.utils import TranspilerTest
+
+class TestStringBytesFixes(unittest.TestCase, TranspilerTest):
+    def test_string_iteration(self):
+        source = """
+        def iterate(s: str):
+            for ch in s:
+                print(ch)
+        """
+        expected = """
+        for ch_u8 in s {
+            ch := ch_u8.ascii_str()
+            println('${ch}')
+        }
+        """
+        self.assert_transpilation(source, expected)
+
+    def test_string_enumerate(self):
+        source = """
+        def iterate_enum(s: str):
+            for i, ch in enumerate(s):
+                print(i, ch)
+        """
+        expected = """
+        for i, ch_u8 in s {
+            ch := ch_u8.ascii_str()
+            println('${i} ${ch}')
+        }
+        """
+        self.assert_transpilation(source, expected)
+
+    def test_bytes_conversion(self):
+        source = """
+        def to_bytes(msg: str):
+            b1 = bytes(msg, "utf8")
+            b2 = bytes(msg, encoding="utf-8")
+            print(b1, b2)
+        """
+        expected = """
+        b1 := msg.bytes()
+        b2 := msg.bytes()
+        """
+        self.assert_transpilation(source, expected)
+
+    def test_int_conversion(self):
+        source = """
+        import sys
+        def to_int():
+            val = int(sys.argv[1])
+            return val
+        """
+        # Note: os.args is used when sys.argv is encountered
+        expected = """
+        val := py_subscript(os.args, 1).int()
+        """
+        self.assert_transpilation(source, expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This submission fixes several issues related to string and bytes handling in the transpiler:
1. String iteration now correctly yields single-character strings instead of bytes by injecting `.ascii_str()` conversion into the loop body. This also works correctly with `enumerate()`.
2. `bytes()` calls with encoding arguments (positional or keyword) are now correctly mapped to V's `.bytes()` method.
3. `int()` calls on `sys.argv` elements are now correctly transpiled to `.int()` by improving the type inference for command-line arguments.
Comprehensive tests were added to verify these fixes.

Fixes #188

---
*PR created automatically by Jules for task [7037063203629885557](https://jules.google.com/task/7037063203629885557) started by @yaskhan*