### PR TITLE
Implement Mypy Error Code to V Tips Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ This transpiler supports a wide range of Python language features and standard l
 
 ### Core Language Support
 -   **Variables & Types**: Type inference using `mypy` (int, float, bool, str, lists, dicts, tuples, sets).
+-   **Mypy Error Tips**: Translates common mypy error codes into actionable V-specific guidance to help fix type issues for better transpilation. Supported mappings:
+    - `[union-attr]`: Guidance on type checking before attribute access.
+    - `[arg-type]`: Strict argument typing requirements in V.
+    - `[return-value]`: Matching return values to signatures.
+    - `[assignment]`: Static typing and reassignment restrictions.
+    - `[index]`: Integer index and map key type requirements.
+    - `[attr-defined]`: Struct field and method existence.
+    - `[operator]`: Operand type compatibility.
+    - `[call-arg]`: Exact parameter count matching.
+    - `[name-defined]`: Variable and function declaration scope.
+    - `[misc]` (for TypeForm): Experimental feature warnings.
 -   **Control Flow**: `if`, `elif`, `else`, `for`, `while`, `match`/`case` pattern matching.
 -   **Functions**: Function definitions, arguments, return values, lambdas, and decorators.
 -   **Object-Oriented Programming**: Classes, inheritance (via struct embedding), method overriding, `__init__`, and operator overloading (`__add__`, etc.).

--- a/py2v_transpiler/core/mypy_tips.py
+++ b/py2v_transpiler/core/mypy_tips.py
@@ -1,0 +1,44 @@
+
+import re
+
+MYPY_TIPS = {
+    "union-attr": "In V, you must explicitly check the type (e.g., using `if x is Type`) before accessing a union attribute.",
+    "arg-type": "In V, function arguments are strictly typed. Ensure the passed value matches the expected type or use a sum type.",
+    "return-value": "V requires the return value to strictly match the function signature.",
+    "assignment": "V is statically typed; ensure the variable type matches the value being assigned. Re-assignments to different types are not allowed.",
+    "index": "V array indices must be integers. Map keys must match the declared key type.",
+    "attr-defined": "Ensure the struct field or method exists in the V definition. V does not allow dynamic attribute addition.",
+    "operator": "V is strict about operand types. Ensure both sides of the operator have compatible types.",
+    "call-arg": "V function calls must match the exact number of defined parameters. Optional arguments in Python are often handled via Optionals or default values in V.",
+    "name-defined": "In V, all variables and functions must be declared before use or be visible in the current module scope.",
+    "misc": {
+        "TypeForm": "Experimental feature 'TypeForm' detected. Use --experimental flag if supported, or simplify the type usage for V compatibility."
+    }
+}
+
+def get_mypy_tips(mypy_output: str) -> str:
+    """
+    Parses mypy output and returns a formatted string of V-specific tips
+    based on the error codes found.
+    """
+    if not mypy_output:
+        return ""
+
+    found_codes = set(re.findall(r"\[([a-z-]+)\]", mypy_output))
+    tips = []
+
+    for code in sorted(found_codes):
+        if code in MYPY_TIPS:
+            tip = MYPY_TIPS[code]
+            if isinstance(tip, dict):
+                # Special handling for 'misc' or other multi-context codes
+                for subkey, subtip in tip.items():
+                    if subkey in mypy_output:
+                        tips.append(f"- [{code}] {subtip}")
+            else:
+                tips.append(f"- [{code}] {tip}")
+
+    if not tips:
+        return ""
+
+    return "\nV-specific tips for found Mypy errors:\n" + "\n".join(tips) + "\n"

--- a/py2v_transpiler/main.py
+++ b/py2v_transpiler/main.py
@@ -9,6 +9,7 @@ from py2v_transpiler.core.parser import PyASTParser
 from py2v_transpiler.core.analyzer import TypeInference
 from py2v_transpiler.core.translator import VNodeVisitor
 from py2v_transpiler.core.dependencies import DependencyAnalyzer
+from py2v_transpiler.core.mypy_tips import get_mypy_tips
 
 class Transpiler:
     def transpile(self, source_code: str) -> str:
@@ -107,7 +108,15 @@ def transpile_file(source_file: str, config: TranspilerConfig, global_helpers: O
     # 3. Analyze types
     analyzer = TypeInference()
     if config.mypy_enabled:
-        analyzer.run_mypy(source_file)
+        stdout, stderr, exit_code = analyzer.run_mypy(source_file)
+        if exit_code != 0:
+            print(f"Mypy found errors in {source_file}:")
+            print(stdout)
+            if stderr:
+                print(stderr, file=sys.stderr)
+            tips = get_mypy_tips(stdout)
+            if tips:
+                print(tips)
 
     # Run basic AST visitor for type inference regardless of mypy
     analyzer.analyze(tree)

--- a/py2v_transpiler/tests/test_mypy_tips.py
+++ b/py2v_transpiler/tests/test_mypy_tips.py
@@ -1,0 +1,33 @@
+
+from py2v_transpiler.core.mypy_tips import get_mypy_tips
+
+def test_get_mypy_tips_union_attr():
+    mypy_output = "error_test.py:3: error: Item \"int\" of \"int | None\" has no attribute \"upper\"  [union-attr]"
+    tips = get_mypy_tips(mypy_output)
+    assert "[union-attr]" in tips
+    assert "explicitly check the type" in tips
+
+def test_get_mypy_tips_multiple_errors():
+    mypy_output = """
+    file.py:10: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
+    file.py:20: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
+    """
+    tips = get_mypy_tips(mypy_output)
+    assert "[assignment]" in tips
+    assert "[arg-type]" in tips
+    assert tips.count("- [") == 2
+
+def test_get_mypy_tips_misc_typeform():
+    mypy_output = "file.py:5: error: TypeForm is experimental  [misc]"
+    tips = get_mypy_tips(mypy_output)
+    assert "[misc]" in tips
+    assert "Experimental feature 'TypeForm' detected" in tips
+
+def test_get_mypy_tips_no_codes():
+    mypy_output = "Some random error without a code"
+    tips = get_mypy_tips(mypy_output)
+    assert tips == ""
+
+def test_get_mypy_tips_empty_input():
+    assert get_mypy_tips("") == ""
+    assert get_mypy_tips(None) == ""


### PR DESCRIPTION
This change improves the user experience by providing actionable V-specific guidance when Mypy detects type errors in Python source code. It bridges the gap between Python's type system and V's static typing requirements.

Key changes:
- New module `mypy_tips.py` for error code resolution.
- Integration in `main.py` to show tips during transpilation.
- Support for `[union-attr]`, `[arg-type]`, `[assignment]`, and more, including special handling for `[misc]` with `TypeForm`.
- Comprehensive test coverage for the new mapping logic.

Fixes #205

---
*PR created automatically by Jules for task [10263510725267765224](https://jules.google.com/task/10263510725267765224) started by @yaskhan*