### PR TITLE
Implement Guard Expressions with Type Narrowing

### DIFF
--- a/py2v_transpiler/core/translator/control_flow_split/match.py
+++ b/py2v_transpiler/core/translator/control_flow_split/match.py
@@ -10,12 +10,14 @@ class MatchMixin(TranslatorBase):
         self._zip_counter += 1
         match_id = self._zip_counter
         subject_var = f"_match_subject_{match_id}"
+        found_var = f"_match_found_{match_id}"
 
-        self.output.append(f"{self._indent()}// Match statement converted to if-else chain")
+        self.output.append(f"{self._indent()}// Match statement converted to separate if blocks")
         self.output.append(f"{self._indent()}{subject_var} := {subject}")
         # Create an 'any' alias for type checking
         subject_any = f"_match_subject_any_{match_id}"
         self.output.append(f"{self._indent()}{subject_any} := Any({subject_var})")
+        self.output.append(f"{self._indent()}mut {found_var} := false")
 
         # Flatten MatchOr patterns to simplify code generation
         expanded_cases = []
@@ -28,33 +30,37 @@ class MatchMixin(TranslatorBase):
             else:
                 expanded_cases.append(case)
 
-        is_first = True
         for case in expanded_cases:
             cond, bindings = self._compile_pattern(case.pattern, subject_any)
 
-            if case.guard:
-                guard_expr = self.visit(case.guard)
-                cond = f"({cond}) && ({guard_expr})"
-
-            prefix = "if" if is_first else "else if"
             if cond == "true":
-                # Wildcard or fallback
-                prefix = "else"
-                self.output.append(f"{self._indent()}{prefix} {{")
+                self.output.append(f"{self._indent()}if !{found_var} {{")
             else:
-                self.output.append(f"{self._indent()}{prefix} {cond} {{")
+                self.output.append(f"{self._indent()}if !{found_var} && ({cond}) {{")
 
             self._indent_level += 1
             for binding in bindings:
                 self.output.append(f"{self._indent()}{binding}")
-            for stmt in case.body:
-                self.visit(stmt)
+
+            if case.guard:
+                guard_expr = self.visit(case.guard)
+                self.output.append(f"{self._indent()}if ({guard_expr}) {{")
+                self._indent_level += 1
+                for stmt in case.body:
+                    self.visit(stmt)
+                self.output.append(f"{self._indent()}{found_var} = true")
+                self._indent_level -= 1
+                self.output.append(f"{self._indent()}}}")
+            else:
+                for stmt in case.body:
+                    self.visit(stmt)
+                self.output.append(f"{self._indent()}{found_var} = true")
+
             self._indent_level -= 1
             self.output.append(f"{self._indent()}}}")
 
-            if cond == "true":
-                break # Stop processing further cases as this one matches everything
-            is_first = False
+            if cond == "true" and not case.guard:
+                break # Optimization: literal wildcard with no guard always matches
 
     def _compile_pattern(self, pattern: ast.AST, subject_expr: str) -> Tuple[str, List[str]]:
         bindings: List[str] = []
@@ -247,14 +253,26 @@ class MatchMixin(TranslatorBase):
                          val_expr = f"({subject_expr} as bool)"
                      else:
                          val_expr = f"({subject_expr} as {cls_name})"
+                 else:
+                     # General type narrowing from mypy for the bound name
+                     if pattern.name:
+                        temp_node = ast.Name(id=pattern.name, ctx=ast.Store(), lineno=getattr(pattern, 'lineno', 0), col_offset=getattr(pattern, 'col_offset', 0))
+                        narrowed_type = self._guess_type(temp_node)
+                        if narrowed_type not in ("Any", "void"):
+                             val_expr = f"({subject_expr} as {narrowed_type})"
 
              if pattern.name:
                  bindings.append(f"{pattern.name} := {val_expr}")
              return cond, bindings
 
         elif isinstance(pattern, ast.MatchStar):
+             val_expr = subject_expr
              if pattern.name:
-                 bindings.append(f"{pattern.name} := {subject_expr}")
+                 temp_node = ast.Name(id=pattern.name, ctx=ast.Store(), lineno=getattr(pattern, 'lineno', 0), col_offset=getattr(pattern, 'col_offset', 0))
+                 narrowed_type = self._guess_type(temp_node)
+                 if narrowed_type not in ("Any", "void"):
+                      val_expr = f"({subject_expr} as {narrowed_type})"
+                 bindings.append(f"{pattern.name} := {val_expr}")
              return "true", bindings
 
         return "false", bindings

--- a/py2v_transpiler/tests/test_match_guards.py
+++ b/py2v_transpiler/tests/test_match_guards.py
@@ -1,0 +1,91 @@
+import os
+import subprocess
+import pytest
+
+def test_match_guards_transpilation():
+    code = """
+class User:
+    def __init__(self, name: str):
+        self.name = name
+
+def check_user(u: object) -> str:
+    match u:
+        case User(name=n) if len(n) > 5:
+            return "Long: " + n
+        case User(name=n):
+            return "Short: " + n
+        case str(s) if s.startswith("a"):
+            return "Starts with a: " + s
+        case _:
+            return "Other"
+
+def test_main():
+    assert check_user(User("Alice")) == "Short: Alice"
+    assert check_user(User("Bob")) == "Short: Bob"
+    assert check_user(User("Alexander")) == "Long: Alexander"
+    assert check_user("apple") == "Starts with a: apple"
+    assert check_user("banana") == "Other"
+    assert check_user(123) == "Other"
+
+if __name__ == "__main__":
+    test_main()
+"""
+    with open("temp_match_guards.py", "w") as f:
+        f.write(code)
+
+    try:
+        # Transpile with --no-mypy for simple structure check
+        result = subprocess.run(["python3", "py2v_transpiler/main.py", "temp_match_guards.py", "--no-mypy"],
+                               capture_output=True, text=True, env={**os.environ, "PYTHONPATH": "."})
+        assert result.returncode == 0, f"Transpilation failed: {result.stderr}"
+
+        # Verify generated V code
+        with open("temp_match_guards.v", "r") as f:
+            v_code = f.read()
+
+        # Check for _match_found flag
+        assert "_match_found_1" in v_code
+        # Check for guard if block with parentheses
+        assert "if (len(n) > 5) {" in v_code
+
+    finally:
+        if os.path.exists("temp_match_guards.py"): os.remove("temp_match_guards.py")
+        if os.path.exists("temp_match_guards.v"): os.remove("temp_match_guards.v")
+        if os.path.exists("temp_match_guards_helpers.v"): os.remove("temp_match_guards_helpers.v")
+
+def test_match_guard_fallthrough():
+    code = """
+def check_val(x: object) -> str:
+    match x:
+        case int(n) if n > 10:
+            return "Large int"
+        case int(n):
+            return "Small int"
+        case _:
+            return "Not an int"
+
+def test_main():
+    assert check_val(15) == "Large int"
+    assert check_val(5) == "Small int"
+    assert check_val("hi") == "Not an int"
+"""
+    with open("temp_fallthrough.py", "w") as f:
+        f.write(code)
+
+    try:
+        # Transpile
+        result = subprocess.run(["python3", "py2v_transpiler/main.py", "temp_fallthrough.py", "--no-mypy"],
+                               capture_output=True, text=True, env={**os.environ, "PYTHONPATH": "."})
+        assert result.returncode == 0
+
+        with open("temp_fallthrough.v", "r") as f:
+            v_code = f.read()
+
+        # Verify that we have separate if blocks for the same pattern 'int'
+        # because we refactored it to separate blocks.
+        assert v_code.count("is int") >= 2
+
+    finally:
+        if os.path.exists("temp_fallthrough.py"): os.remove("temp_fallthrough.py")
+        if os.path.exists("temp_fallthrough.v"): os.remove("temp_fallthrough.v")
+        if os.path.exists("temp_fallthrough_helpers.v"): os.remove("temp_fallthrough_helpers.v")

--- a/py2v_transpiler/tests/translator/test_match_pattern.py
+++ b/py2v_transpiler/tests/translator/test_match_pattern.py
@@ -22,8 +22,10 @@ match x:
         pass
 """
     v_code = translate(source)
-    # Expect if condition with guard
-    assert "if (_match_subject_any_1 == 1) && (x > 0)" in v_code
+    # New refactored structure uses separate if blocks with _match_found flag
+    assert "_match_found_1" in v_code
+    assert "if !_match_found_1 && (_match_subject_any_1 == 1) {" in v_code
+    assert "if (x > 0) {" in v_code
 
 def test_match_sequence():
     source = """
@@ -102,7 +104,8 @@ match x:
         pass
 """
     v_code = translate(source)
-    assert "else {" in v_code
+    # New structure uses separate if blocks
+    assert "if !_match_found_1 {" in v_code
 
 def test_match_class():
     source = """


### PR DESCRIPTION
This PR implements PEP 634 guard expressions with integrated type narrowing for `match/case` statements.

### Key Changes:
- **Structural Refactor**: `match` statements are now transpiled to a sequence of `if` blocks controlled by a `_match_found_N` flag. This change is necessary because V's `else if` does not support establishing bindings and then "falling through" to the next branch if a nested guard condition fails.
- **Guard Support**: Pattern bindings are now emitted at the top of each case block, making them available for guard expressions.
- **Type Narrowing**: `MatchAs` and `MatchStar` now attempt to resolve narrowed types for bound variables using the transpiler's type inference engine, injecting explicit V type casts where appropriate.
- **Testing**: Updated `test_match_pattern.py` and added `test_match_guards.py`. All 503 tests pass.

Fixes #202

---
*PR created automatically by Jules for task [6406077495518829190](https://jules.google.com/task/6406077495518829190) started by @yaskhan*