### PR TITLE
Implement Generic Match Patterns with Type Parameters

### DIFF
--- a/py2v_transpiler/core/compatibility.py
+++ b/py2v_transpiler/core/compatibility.py
@@ -34,8 +34,65 @@ class CompatibilityLayer:
         to support newer or future syntax on older Python versions.
         """
         source = self._preprocess_bracketless_except(source)
+        source = self._preprocess_generic_match(source)
         # Add more future pre-processors here
         return source
+
+    def _preprocess_generic_match(self, source: str) -> str:
+        """
+        Pre-processes Python source code to mangle generic class patterns in match statements
+        to be parsable by the standard ast module.
+        Supports multi-line patterns, nested generics, and qualified names.
+        Example: `case Box[int](value=v):` becomes `case Box__py2v_gen_L__int__py2v_gen_R__(value=v):`.
+        """
+        def mangle_recursive(text: str) -> str:
+            def mangle_callback(match: re.Match) -> str:
+                name, args = match.groups()
+                # Replace remaining separators in this level
+                mangled_args = args.replace(', ', '__py2v_gen_C__').replace(',', '__py2v_gen_C__').replace(' ', '')
+                return f"{name}__py2v_gen_L__{mangled_args}__py2v_gen_R__"
+
+            new_text = text
+            while True:
+                # Matches Word or pkg.Word followed by [Inner] where Inner doesn't contain [ or ]
+                temp = re.sub(r'(\b[\w\.]+)\[([^\[\]]+)\]', mangle_callback, new_text)
+                if temp == new_text:
+                    break
+                new_text = temp
+            return new_text
+
+        result = []
+        lines = source.split('\n')
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            case_match = re.match(r'^(\s*)case\s+(.*)', line)
+            if case_match:
+                indent = case_match.group(1)
+                content = case_match.group(2)
+
+                # Find the colon ending the case pattern
+                full_case_content = content
+                j = i
+                while ':' not in full_case_content and j + 1 < len(lines):
+                    j += 1
+                    full_case_content += '\n' + lines[j]
+
+                if ':' in full_case_content:
+                    # Split into pattern and rest
+                    pattern_part, rest_part = full_case_content.split(':', 1)
+                    mangled_pattern = mangle_recursive(pattern_part)
+
+                    new_full_case = f"{indent}case {mangled_pattern}:{rest_part}"
+                    new_lines = new_full_case.split('\n')
+                    result.extend(new_lines)
+                    i = j + 1
+                    continue
+
+            result.append(line)
+            i += 1
+
+        return '\n'.join(result)
 
     def _preprocess_bracketless_except(self, source: str) -> str:
         """

--- a/py2v_transpiler/core/translator/control_flow_split/match.py
+++ b/py2v_transpiler/core/translator/control_flow_split/match.py
@@ -5,6 +5,20 @@ from ..base import TranslatorBase
 class MatchMixin(TranslatorBase):
     """Обработка match/case (Python 3.10+)"""
     
+    def _unmangle_generic_name(self, name: str) -> str:
+        """Restores generic syntax from mangled identifiers and maps Python types to V types."""
+        from py2v_transpiler.models.v_types import map_python_type_to_v
+        if "__py2v_gen_L__" not in name:
+            return map_python_type_to_v(name)
+
+        # Restore original syntax
+        res = name.replace("__py2v_gen_L__", "[")
+        res = res.replace("__py2v_gen_R__", "]")
+        res = res.replace("__py2v_gen_C__", ", ")
+
+        # Now map it properly using map_python_type_to_v
+        return map_python_type_to_v(res)
+
     def visit_Match(self, node: "ast.Match") -> None:
         subject = self.visit(node.subject)
         self._zip_counter += 1
@@ -200,15 +214,8 @@ class MatchMixin(TranslatorBase):
 
         elif isinstance(pattern, ast.MatchClass):
              cls_name = self.visit(pattern.cls)
-             # Map Python builtin types to V types
-             if cls_name == "int":
-                 cls_name = "int"
-             elif cls_name == "float":
-                 cls_name = "f64"
-             elif cls_name == "str":
-                 cls_name = "string"
-             elif cls_name == "bool":
-                 cls_name = "bool"
+             # Restore generic syntax if mangled and map Python types to V types
+             cls_name = self._unmangle_generic_name(cls_name)
 
              cond = f"({subject_expr} is {cls_name})"
 
@@ -293,16 +300,8 @@ class MatchMixin(TranslatorBase):
                  # Narrowing: if the sub-pattern is a specific class, we can cast the variable
                  if isinstance(pattern.pattern, ast.MatchClass):
                      cls_name = self.visit(pattern.pattern.cls)
-                     if cls_name == "int":
-                         val_expr = f"({subject_expr} as int)"
-                     elif cls_name == "float":
-                         val_expr = f"({subject_expr} as f64)"
-                     elif cls_name == "str":
-                         val_expr = f"({subject_expr} as string)"
-                     elif cls_name == "bool":
-                         val_expr = f"({subject_expr} as bool)"
-                     else:
-                         val_expr = f"({subject_expr} as {cls_name})"
+                     cls_name = self._unmangle_generic_name(cls_name)
+                     val_expr = f"({subject_expr} as {cls_name})"
                  else:
                      # General type narrowing from mypy for the bound name
                      if pattern.name:

--- a/py2v_transpiler/tests/translator/test_generic_match.py
+++ b/py2v_transpiler/tests/translator/test_generic_match.py
@@ -1,0 +1,75 @@
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.analyzer import TypeInference
+from py2v_transpiler.core.translator import VNodeVisitor
+
+def translate(source: str) -> str:
+    parser = PyASTParser()
+    tree = parser.parse(source)
+    if not isinstance(tree, ast.Module):
+        raise ValueError("Parsed AST is not a Module")
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+    v_code = translator.visit_Module(tree)
+    return v_code
+
+def test_generic_match_basic():
+    source = """
+match x:
+    case Box[int](value=v):
+        pass
+"""
+    v_code = translate(source)
+    assert "is Box[int]" in v_code
+    assert "as Box[int]" in v_code
+
+def test_generic_match_nested():
+    source = """
+match x:
+    case Container[Box[str]](inner=b):
+        pass
+"""
+    v_code = translate(source)
+    assert "is Container[Box[string]]" in v_code
+    assert "as Container[Box[string]]" in v_code
+
+def test_generic_match_multiple_args():
+    source = """
+match x:
+    case Pair[int, str](first=f, second=s):
+        pass
+"""
+    v_code = translate(source)
+    assert "is Pair[int, string]" in v_code
+    assert "as Pair[int, string]" in v_code
+
+def test_generic_match_as_narrowing():
+    source = """
+match x:
+    case Box[float](value=v) as b:
+        pass
+"""
+    v_code = translate(source)
+    assert "b := (_match_subject_any_1 as Box[f64])" in v_code
+    # Wait, float maps to f64 in MatchClass, but let's check _unmangle_generic_name doesn't interfere.
+    # In my verify_generics it showed Box[int] which is correct because int maps to int.
+    # float should map to f64.
+
+def test_generic_match_with_guard():
+    source = """
+match x:
+    case Box[int](value=v) if v > 0:
+        pass
+"""
+    v_code = translate(source)
+    assert "is Box[int]" in v_code
+    assert "if (v > 0) {" in v_code
+
+def test_generic_match_deeply_nested():
+    source = """
+match x:
+    case A[B[C[D]]](val=v):
+        pass
+"""
+    v_code = translate(source)
+    assert "is A[B[C[D]]]" in v_code


### PR DESCRIPTION
This change implements support for type-parameterized class patterns in Python 3.10+ match statements (e.g., `case Box[int](value=v):`). 

Since Python's standard `ast.parse` does not yet support this syntax in match patterns (as it's part of proposed PEPs or newer versions than current environment), a robust preprocessing step was added to `CompatibilityLayer`. This step identifies these patterns (including nested ones like `Container[Box[str]]`) and mangles them into valid identifiers using markers (`__py2v_gen_L__`, `__py2v_gen_R__`, `__py2v_gen_C__`).

The `MatchMixin` then unmangles these identifiers during translation and utilizes `map_python_type_to_v` to ensure that generic arguments are correctly translated to V types (e.g., mapping `str` to `string`). This ensures that generated V code like `subject is Box[int]` or `subject is Container[Box[string]]` is valid and semantically correct.

The implementation also supports type narrowing in `as` patterns and multi-line `case` patterns.

Acceptance Criteria met:
- Generic class pattern parsing via preprocessing
- Type argument extraction and recursive mapping to V
- Test cases for various generic match patterns
- Support for nested and multiple generic arguments


Fixes #197

---
*PR created automatically by Jules for task [12660923934565070766](https://jules.google.com/task/12660923934565070766) started by @yaskhan*