### PR TITLE
Enforce snake_case for generated factory functions

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -239,6 +239,10 @@ class TranslatorBase(ast.NodeVisitor):
             res.append(char.lower())
         return "".join(res)
 
+    def _get_factory_name(self, struct_name: str) -> str:
+        """Returns a snake_case factory name for a given struct name."""
+        return f"new_{self._to_snake_case(struct_name)}"
+
     def _get_generic_map(self, generic_names: List[str]) -> Dict[str, str]:
         """
         Generates a mapping from Python generic names to unique single-character V generic names.

--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -667,9 +667,10 @@ class ClassesMixin(TranslatorBase):
 
             pub = "pub " if self._is_exported(node.name) else ""
             gen_str = f"[{', '.join(self.current_class_generics)}]" if self.current_class_generics else ""
+            factory_name = self._get_factory_name(struct_name)
 
             factory_code = [
-                f"{pub}fn new_{struct_name}{gen_str}({', '.join(factory_args)}) {struct_name}{gen_str} {{",
+                f"{pub}fn {factory_name}{gen_str}({', '.join(factory_args)}) {struct_name}{gen_str} {{",
                 f"    mut self := {struct_name}{gen_str}{{{', '.join(struct_init_args)}}}",
                 f"    self.post_init({', '.join(post_init_args)})",
                 f"    return self",

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -229,7 +229,8 @@ class CallsMixin(TranslatorBase):
                 if self.current_class_bases:
                     parent = self.current_class_bases[0]
                     if method_name == "__init__":
-                        return f"self.{parent} = new_{parent}({', '.join(args)})"
+                        factory_name = self._get_factory_name(parent)
+                        return f"self.{parent} = {factory_name}({', '.join(args)})"
                     return f"self.{parent}.{method_name}({', '.join(args)})"
                 else:
                     return f"/* super().{method_name} call without known parent */"
@@ -241,7 +242,8 @@ class CallsMixin(TranslatorBase):
                 if self.current_class_bases and class_name in self.current_class_bases:
                     if len(args) >= 1 and args[0] == "self":
                         base_args = args[1:]
-                        return f"self.{class_name} = new_{class_name}({', '.join(base_args)})"
+                        factory_name = self._get_factory_name(class_name)
+                        return f"self.{class_name} = {factory_name}({', '.join(base_args)})"
 
         # Handle unittest assertions
         # Strictly check for self.assertX if possible to avoid regressions
@@ -604,7 +606,8 @@ class CallsMixin(TranslatorBase):
                                      # Fallback to zero value or placeholder if not found
                                      pass
 
-                return f"new_{func_name_str}({', '.join(final_factory_args)})"
+                factory_name = self._get_factory_name(func_name_str)
+                return f"{factory_name}({', '.join(final_factory_args)})"
             return f"{func_name_str}{{{', '.join(struct_args)}}}"
         elif hasattr(self, 'dataclasses') and func_name_str in self.dataclasses:
             field_order = self.dataclasses[func_name_str]
@@ -644,7 +647,8 @@ class CallsMixin(TranslatorBase):
 
         if is_class:
             if has_factory:
-                return f"new_{func_name_str}({', '.join(args)})"
+                factory_name = self._get_factory_name(func_name_str)
+                return f"{factory_name}({', '.join(args)})"
             else:
                 return f"{func_name_str}{{{', '.join(args)}}}"
 

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -284,7 +284,7 @@ class FunctionsMixin(TranslatorBase):
         if node.name == "__new__":
             is_new_method = True
             # Rename __new__ to factory name
-            node.name = f"new_{struct_name}"
+            node.name = self._get_factory_name(struct_name)
             # Remove 'cls' argument if present
             if args and args[0].arg == "cls":
                 args = args[1:]
@@ -463,7 +463,7 @@ class FunctionsMixin(TranslatorBase):
                 # is_method remains True, receiver_str is already set
             else:
                 is_init = True
-                func_name = f"new_{struct_name}"
+                func_name = self._get_factory_name(struct_name)
                 receiver_str = ""  # Factory is static
                 ret_type = struct_name
                 if self.current_class_generics:

--- a/py2v_transpiler/tests/test_v2_features.py
+++ b/py2v_transpiler/tests/test_v2_features.py
@@ -31,7 +31,7 @@ class Child(Base[int]):
     assert "struct Base[T] {" in v_code
     assert "struct Child {" in v_code
     assert "Base[int]" in v_code
-    assert "fn new_Base[T](val T) Base[T]" in v_code
+    assert "fn new_base[T](val T) Base[T]" in v_code
     assert "fn (self Child) method(x U) U" in v_code
 
 def test_comparisons():

--- a/py2v_transpiler/tests/translator/test_classes.py
+++ b/py2v_transpiler/tests/translator/test_classes.py
@@ -31,7 +31,7 @@ class Point:
     assert "y int" in result
 
     # Check factory function for __init__
-    assert "fn new_Point(x int, y int) Point {" in result
+    assert "fn new_point(x int, y int) Point {" in result
     assert "self.x = x" in result
 
     # Check method

--- a/py2v_transpiler/tests/translator/test_constructors.py
+++ b/py2v_transpiler/tests/translator/test_constructors.py
@@ -24,7 +24,7 @@ class Decimal:
         return object.__new__(cls)
 """
         result = self.transpile(source)
-        self.assertIn("fn new_Decimal(value string) Decimal {", result)
+        self.assertIn("fn new_decimal(value string) Decimal {", result)
         self.assertIn("return Decimal{}", result)
         # Should NOT have __new__ method
         self.assertNotIn("__new__", result)
@@ -37,7 +37,7 @@ class Point:
         self.y = y
 """
         result = self.transpile(source)
-        self.assertIn("fn new_Point(x int, y int) Point {", result)
+        self.assertIn("fn new_point(x int, y int) Point {", result)
         self.assertIn("mut self := Point{}", result)
 
     def test_new_and_init(self):
@@ -50,8 +50,8 @@ class Decimal:
         self.value = value
 """
         result = self.transpile(source)
-        self.assertIn("fn new_Decimal(value string) Decimal {", result)
-        self.assertIn("return new_Decimal()", result)
+        self.assertIn("fn new_decimal(value string) Decimal {", result)
+        self.assertIn("return new_decimal()", result)
         self.assertIn("fn (self Decimal) init(value string) {", result)
 
     def test_instantiation_new(self):
@@ -64,7 +64,7 @@ d = Decimal("1.2")
         # We need visit_Module to see the main block
         tree = ast.parse(source)
         res_module = self.translator.visit_Module(tree)
-        self.assertIn("d := new_Decimal('1.2')", res_module)
+        self.assertIn("d := new_decimal('1.2')", res_module)
 
     def test_instantiation_init(self):
         source = """
@@ -75,7 +75,7 @@ p = Point(1)
 """
         tree = ast.parse(source)
         res_module = self.translator.visit_Module(tree)
-        self.assertIn("p := new_Point(1)", res_module)
+        self.assertIn("p := new_point(1)", res_module)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py2v_transpiler/tests/translator/test_mixins.py
+++ b/py2v_transpiler/tests/translator/test_mixins.py
@@ -25,7 +25,7 @@ fn (self User) login() {
     self.is_authenticated = true
 }
 
-fn new_User(username string) User {
+fn new_user(username string) User {
     mut self := User{}
     self.username = username
     return self

--- a/py2v_transpiler/tests/translator/test_todo_tasks.py
+++ b/py2v_transpiler/tests/translator/test_todo_tasks.py
@@ -90,7 +90,7 @@ class MyClass:
         pass
 """
         result = self.transpile(source)
-        self.assertIn("fn new_MyClass() {", result)
+        self.assertIn("fn new_my_class() {", result)
 
     def test_ellipsis_literal(self):
         source = """


### PR DESCRIPTION
The transpiler was generating factory functions for Python classes using the `new_ClassName` pattern (e.g., `new_Data()`). However, the V compiler requires all function names to be in `snake_case`. This caused compilation errors for any transpiled code that included class instantiations or custom constructors.

I have fixed this by:
1.  Adding a `_get_factory_name(struct_name)` helper to `TranslatorBase` that uses the existing `_to_snake_case` utility.
2.  Updating `ClassesMixin` (dataclass factories), `FunctionsMixin` (constructor renaming), and `CallsMixin` (call-site generation) to use this helper.
3.  Updating all affected tests in the test suite to use the new `new_class_name` naming convention.

Verified the fix with a reproduction script and by running the full test suite (592 tests passing).

Fixes #264

---
*PR created automatically by Jules for task [11051002868225397747](https://jules.google.com/task/11051002868225397747) started by @yaskhan*