### PR TITLE
Collect instance variables from __init__ as struct fields

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -779,6 +779,38 @@ class ClassesMixin(TranslatorBase):
             for method in methods:
                 self.visit(method)
         else:
+            # NEW: Collect fields from __init__ that haven't been added yet
+            for stmt in node.body:
+                if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == "__init__":
+                    if stmt.args.args:
+                        init_self_name = stmt.args.args[0].arg
+                        for sub_node in ast.walk(stmt):
+                            if isinstance(sub_node, ast.Assign):
+                                for target in sub_node.targets:
+                                    for t in ast.walk(target):
+                                        if isinstance(t, ast.Attribute) and isinstance(t.value, ast.Name) and t.value.id == init_self_name:
+                                            field_name = self._sanitize_name(t.attr)
+                                            if field_name not in added_fields:
+                                                added_fields.add(field_name)
+                                                # Try to guess type from value
+                                                f_type = "Any"
+                                                if len(sub_node.targets) == 1 and isinstance(sub_node.targets[0], ast.Attribute):
+                                                    f_type = self._guess_type(sub_node.value)
+                                                fields.append(f"    {field_name} {f_type}")
+                            elif isinstance(sub_node, ast.AnnAssign):
+                                if isinstance(sub_node.target, ast.Attribute) and isinstance(sub_node.target.value, ast.Name) and sub_node.target.value.id == init_self_name:
+                                    field_name = self._sanitize_name(sub_node.target.attr)
+                                    if field_name not in added_fields:
+                                        added_fields.add(field_name)
+                                        f_type = "Any"
+                                        if sub_node.annotation:
+                                            try:
+                                                t_str = ast.unparse(sub_node.annotation)
+                                                f_type = self._map_type(t_str, struct_name)
+                                            except:
+                                                pass
+                                        fields.append(f"    {field_name} {f_type}")
+
             struct_parts = []
             if doc_comment:
                 struct_parts.append(doc_comment)

--- a/py2v_transpiler/tests/translator/test_init_inference.py
+++ b/py2v_transpiler/tests/translator/test_init_inference.py
@@ -1,0 +1,104 @@
+import ast
+import pytest
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+def test_init_inference_basic():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+class Data:
+    def __init__(self):
+        self.value = 0
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "struct Data {" in result
+    assert "value int" in result
+
+def test_init_inference_annotated():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+class Data:
+    def __init__(self):
+        self.value: int | str = 0
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "struct Data {" in result
+    assert "value int | string" in result
+
+def test_init_inference_multiple():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+class Data:
+    def __init__(self, x: int, y: str):
+        self.x = x
+        self.y = y
+        self.z = 0.5
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "struct Data {" in result
+    assert "x int" in result
+    assert "y string" in result
+    assert "z f64" in result
+
+def test_init_inference_nested():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+class Data:
+    def __init__(self, cond: bool):
+        if cond:
+            self.a = 1
+        else:
+            self.b = "hello"
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "struct Data {" in result
+    assert "a int" in result
+    assert "b string" in result
+
+def test_init_inference_mixed():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+class Data:
+    base: int
+    def __init__(self):
+        self.value = 0
+        self.base = 1
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    assert "struct Data {" in result
+    assert "base int" in result
+    assert "value int" in result
+    # Ensure no duplicates in struct definition string
+    assert result.count("base int") == 1
+    assert result.count("value int") == 1


### PR DESCRIPTION
Instance variables declared and initialized inside the `__init__` method (e.g. `self.value = 0` or `self.value: int | str = 0`) were not being collected as fields for the generated V struct when Mypy type inference was not available. This resulted in empty struct definitions and subsequent V compiler errors.

This change modifies `ClassesMixin.visit_ClassDef` to:
1. Identify the `__init__` method.
2. Determine the name of the `self` parameter.
3. Traverse the `__init__` body using `ast.walk` to find all assignments (`ast.Assign` and `ast.AnnAssign`) where the target is an attribute of `self`.
4. Infer the field type using `_guess_type` or the provided annotation.
5. Add these inferred fields to the struct's `fields` list if they haven't been added yet (e.g., from class-level annotations).

A new test suite `py2v_transpiler/tests/translator/test_init_inference.py` was added to verify various scenarios, including basic assignments, annotated assignments, multiple fields, and assignments inside nested blocks (like `if/else`).

Fixes #266

---
*PR created automatically by Jules for task [12065341441197490092](https://jules.google.com/task/12065341441197490092) started by @yaskhan*