### PR TITLE
Generate named sum types for unions

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -105,6 +105,7 @@ class TranslatorBase(ast.NodeVisitor):
         self.used_dict_merge: bool = False
         self.used_string_format: bool = False
         self.dataclasses: Dict[str, List[str]] = {}
+        self._generated_sum_types: Dict[str, str] = {}
         self.global_vars: Set[str] = set()
         self.renamed_functions: Dict[str, str] = {"main": "py_main"}
         self.name_remap: Dict[str, str] = {}
@@ -358,18 +359,70 @@ class TranslatorBase(ast.NodeVisitor):
             return f"{name}{gen_str}"
         return name
 
-    def _map_type(self, type_str: str, struct_name: Optional[str] = None, allow_union: bool = True) -> str:
+    def _register_sum_type(self, v_union_type: str) -> str:
+        """
+        Normalizes a V union type, generates a named sum type if not already exists,
+        and returns its name (including generic args if applicable).
+        """
+        parts = [p.strip() for p in v_union_type.split('|')]
+        if len(parts) <= 1:
+            return v_union_type
+
+        parts.sort()
+        normalized = " | ".join(parts)
+
+        if normalized in self._generated_sum_types:
+            return self._generated_sum_types[normalized]
+
+        # Generate a name: SumType_Part1Part2
+        def clean(s: str) -> str:
+            # Map V types to CamelCase-friendly strings
+            m = {
+                'int': 'Int', 'string': 'String', 'bool': 'Bool', 'f64': 'F64',
+                'i64': 'I64', 'u32': 'U32', 'u64': 'U64', 'i8': 'I8', 'i16': 'I16',
+                'u8': 'U8', 'u16': 'U16', 'Any': 'Any', 'void': 'Void', 'none': 'None'
+            }
+            res = m.get(s, s).replace('[]', 'Array').replace('map', 'Map')
+            return "".join(c for c in res if c.isalnum() or c == '_')
+
+        type_name = "SumType_" + "".join(clean(p) for p in parts)
+
+        # Avoid collisions
+        base_name = type_name
+        counter = 1
+        while any(v == type_name for v in self._generated_sum_types.values()):
+            type_name = f"{base_name}_{counter}"
+            counter += 1
+
+        # Identify active generics used in the union
+        active_v_generics = self._get_all_active_v_generics()
+        used_generics = [g for g in active_v_generics if g in parts or any(f"[{g}]" in p for p in parts) or any(f"{g} " in p for p in parts)]
+
+        gen_decl = f"[{', '.join(used_generics)}]" if used_generics else ""
+        gen_args = f"[{', '.join(used_generics)}]" if used_generics else ""
+
+        pub = "pub " if self.config and getattr(self.config, 'include_all_symbols', False) else ""
+        self.emitter.add_struct(f"{pub}type {type_name}{gen_decl} = {normalized}")
+
+        result = f"{type_name}{gen_args}"
+        self._generated_sum_types[normalized] = result
+        return result
+
+    def _map_type(self, type_str: str, struct_name: Optional[str] = None, allow_union: bool = True, register_sum_types: bool = True) -> str:
         """
         Centralized type mapping that performs map_python_type_to_v
         followed by imported_symbols and SCC-based re-mapping.
         """
         from py2v_transpiler.models.v_types import map_python_type_to_v
 
+        registrar = self._register_sum_type if register_sum_types else None
+
         v_type = map_python_type_to_v(
             type_str,
             self_name=self._get_full_self_type(struct_name),
             generic_map=self._get_combined_generic_map(),
-            allow_union=allow_union
+            allow_union=allow_union,
+            sum_type_registrar=registrar
         )
 
         # Centralize LiteralString to string mapping

--- a/py2v_transpiler/core/translator/variables_split/assignments.py
+++ b/py2v_transpiler/core/translator/variables_split/assignments.py
@@ -105,7 +105,7 @@ class AssignmentsMixin(TranslatorBase):
                               # Unparse RHS to string
                               if hasattr(ast, 'unparse'):
                                   rhs_source = ast.unparse(node.value)
-                                  mapped = map_python_type_to_v(rhs_source, allow_union=True, self_name=self._get_full_self_type())
+                                  mapped = self._map_type(rhs_source, allow_union=True, register_sum_types=False)
                                   # Check if mapped value looks like a type and not void/same-as-input-expression
                                   # map_python_type_to_v returns input if it fails to map usually, unless it parses successfully via _map_ast_type
                                   # For List[int], it returns []int. List[int] != []int.

--- a/py2v_transpiler/core/translator/variables_split/type_alias.py
+++ b/py2v_transpiler/core/translator/variables_split/type_alias.py
@@ -29,7 +29,7 @@ class TypeAliasMixin(TranslatorBase):
 
         if hasattr(ast, 'unparse'):
             val_str = ast.unparse(node.value)
-            v_type = self._map_type(val_str, allow_union=True)
+            v_type = self._map_type(val_str, allow_union=True, register_sum_types=False)
 
             pub = "pub " if self._is_exported(node.name.id) else ""
             self.emitter.add_struct(f"{pub}type {name}{type_params_str} = {v_type}")

--- a/py2v_transpiler/models/v_types.py
+++ b/py2v_transpiler/models/v_types.py
@@ -1,6 +1,6 @@
 import ast
 from enum import Enum, auto
-from typing import Optional
+from typing import Optional, Callable
 
 class VType(Enum):
     INT = auto()
@@ -14,7 +14,7 @@ class VType(Enum):
     NONE = auto()
     UNKNOWN = auto()
 
-def map_python_type_to_v(py_type: str, self_name: str = "Self", allow_union: bool = True, generic_map: Optional[dict[str, str]] = None) -> str:
+def map_python_type_to_v(py_type: str, self_name: str = "Self", allow_union: bool = True, generic_map: Optional[dict[str, str]] = None, sum_type_registrar: Optional[Callable[[str], str]] = None) -> str:
     """Maps a Python type name to its V equivalent."""
     if not py_type:
         return 'void'
@@ -48,11 +48,11 @@ def map_python_type_to_v(py_type: str, self_name: str = "Self", allow_union: boo
     try:
         # Use AST to parse complex types
         node = ast.parse(py_type, mode='eval').body
-        return _map_ast_type(node, self_name, allow_union, generic_map)
+        return _map_ast_type(node, self_name, allow_union, generic_map, sum_type_registrar)
     except SyntaxError:
         return py_type
 
-def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = True, generic_map: Optional[dict[str, str]] = None) -> str:
+def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = True, generic_map: Optional[dict[str, str]] = None, sum_type_registrar: Optional[Callable[[str], str]] = None) -> str:
     if isinstance(node, ast.Name):
         if node.id == "Self":
             return self_name
@@ -100,13 +100,13 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
         if isinstance(node.value, str):
             try:
                 inner_node = ast.parse(node.value, mode='eval').body
-                return _map_ast_type(inner_node, self_name, allow_union, generic_map)
+                return _map_ast_type(inner_node, self_name, allow_union, generic_map, sum_type_registrar)
             except SyntaxError:
                 return node.value
         return str(node.value)
 
     elif isinstance(node, ast.Starred):
-        return _map_ast_type(node.value, self_name, allow_union, generic_map)
+        return _map_ast_type(node.value, self_name, allow_union, generic_map, sum_type_registrar)
 
     elif isinstance(node, ast.Subscript):
         # Handle List[T], Dict[K,V], Optional[T], etc.
@@ -139,7 +139,7 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
             args = [slice_node]
 
         # Helper to map args, handling nested types
-        mapped_args = [_map_ast_type(arg, self_name, allow_union, generic_map) for arg in args]
+        mapped_args = [_map_ast_type(arg, self_name, allow_union, generic_map, sum_type_registrar) for arg in args]
 
         if value_id in ('List', 'list', 'Sequence', 'MutableSequence', 'Iterable', 'Iterator'):
             if mapped_args:
@@ -202,7 +202,13 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
                 for arg in mapped_args:
                     if arg not in unique_args:
                         unique_args.append(arg)
-                return " | ".join(unique_args)
+
+                union_str = " | ".join(unique_args)
+                if sum_type_registrar:
+                    if len(non_none) < len(mapped_args): # had none
+                        return f"?{sum_type_registrar(' | '.join(non_none))}"
+                    return sum_type_registrar(union_str)
+                return union_str
             return "Any"
 
         elif value_id in ('Callable', 'typing.Callable'):
@@ -214,7 +220,7 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
 
                 arg_types = []
                 if isinstance(arg_list_node, ast.List):
-                    arg_types = [_map_ast_type(a, self_name, allow_union, generic_map) for a in arg_list_node.elts]
+                    arg_types = [_map_ast_type(a, self_name, allow_union, generic_map, sum_type_registrar) for a in arg_list_node.elts]
                 elif isinstance(arg_list_node, ast.Name) and generic_map and arg_list_node.id in generic_map:
                     # ParamSpec: Callable[P, Ret]
                     # We usually map P to empty args if it represents the whole signature
@@ -225,9 +231,9 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
                     arg_types = ["..."]
                 elif isinstance(arg_list_node, ast.Name):
                     # ParamSpec: Callable[P, Ret]
-                    arg_types = [_map_ast_type(arg_list_node, self_name, allow_union, generic_map)]
+                    arg_types = [_map_ast_type(arg_list_node, self_name, allow_union, generic_map, sum_type_registrar)]
 
-                ret_type = _map_ast_type(ret_node, self_name, allow_union, generic_map)
+                ret_type = _map_ast_type(ret_node, self_name, allow_union, generic_map, sum_type_registrar)
                 if ret_type == "none": ret_type = "void"
 
                 return f"fn ({', '.join(arg_types)}) {ret_type}"
@@ -282,14 +288,19 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
     elif isinstance(node, ast.BinOp):
         # A | B (Python 3.10+ Union)
         if isinstance(node.op, ast.BitOr):
-            left_type = _map_ast_type(node.left, self_name, allow_union, generic_map)
-            right_type = _map_ast_type(node.right, self_name, allow_union, generic_map)
+            left_type = _map_ast_type(node.left, self_name, allow_union, generic_map, sum_type_registrar)
+            right_type = _map_ast_type(node.right, self_name, allow_union, generic_map, sum_type_registrar)
+
             if left_type == 'none':
                 return f"?{right_type}"
             if right_type == 'none':
                 return f"?{left_type}"
+
             if allow_union:
-                return f"{left_type} | {right_type}"
+                union_str = f"{left_type} | {right_type}"
+                if sum_type_registrar:
+                    return sum_type_registrar(union_str)
+                return union_str
             return "Any"
 
     return "void"

--- a/py2v_transpiler/tests/translator/test_property_mismatched_types.py
+++ b/py2v_transpiler/tests/translator/test_property_mismatched_types.py
@@ -30,7 +30,7 @@ class Config:
         "return self._value",
         "}",
         # Union type is now preserved in setter
-        "fn (self Config) set_value(new_value string | int) {",
+        "fn (self Config) set_value(new_value SumType_IntString) {",
         "if new_value is str {",
     ]
 
@@ -136,7 +136,7 @@ class Result:
     print()
 
     # Getter with union type should use union
-    assert "fn (self Result) value() int | string {" in code
+    assert "fn (self Result) value() SumType_IntString {" in code
     # Setter accepts int
     assert "fn (self Result) set_value(new_value int) {" in code
 
@@ -197,4 +197,4 @@ class Measurement:
     # Getter returns f64
     assert "fn (self Measurement) value() f64 {" in code
     # Setter accepts union type
-    assert "fn (self Measurement) set_value(new_value int | f64) {" in code
+    assert "fn (self Measurement) set_value(new_value SumType_F64Int) {" in code

--- a/py2v_transpiler/tests/translator/test_union_types.py
+++ b/py2v_transpiler/tests/translator/test_union_types.py
@@ -17,8 +17,9 @@ class TestUnionTypes(unittest.TestCase):
     def test_union_arg(self):
         source = "def f(x: int | str): pass"
         result = self.transpile(source)
-        # Should be 'x int | string'
-        self.assertIn("x int | string", result)
+        # Should be 'x SumType_IntString'
+        self.assertIn("type SumType_IntString = int | string", result)
+        self.assertIn("x SumType_IntString", result)
 
     def test_optional_union_arg(self):
         source = "def f(x: int | None): pass"


### PR DESCRIPTION
Modified the transpiler to generate named sum types instead of deprecated inline sum types in V.
Implemented a registration system that creates unique, stable names for unions, handles generics, and prevents redundant declarations for explicit type aliases.
Updated the test suite to match the new output format.

Fixes #265

---
*PR created automatically by Jules for task [11465283135386665115](https://jules.google.com/task/11465283135386665115) started by @yaskhan*