### PR TITLE
Fix invalid optional channel syntax in generator translation

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -898,7 +898,7 @@ class CallsMixin(TranslatorBase):
              # x := gen
              # This order is CORRECT for V.
 
-             self.output.append(f"{self._indent()}{ch_out_name} := chan ?{yield_type}{{cap: 0}}")
+             self.output.append(f"{self._indent()}{ch_out_name} := chan {yield_type}{{cap: 0}}")
              self.output.append(f"{self._indent()}{ch_in_name} := chan PyGeneratorInput{{cap: 0}}")
              self.output.append(f"{self._indent()}{gen_var_name} := PyGenerator[{yield_type}]{{out: {ch_out_name}, in_: {ch_in_name}}}")
 

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -268,7 +268,7 @@ class FunctionsMixin(TranslatorBase):
         if is_generator:
             # Inject channel argument
             yield_type = self.coroutine_handler.get_yield_type(node)
-            args_str_list.append(f"ch_out chan ?{yield_type}")
+            args_str_list.append(f"ch_out chan {yield_type}")
             args_str_list.append(f"ch_in chan PyGeneratorInput")
             self.coroutine_handler.enter_generator("ch_out", "ch_in")
 
@@ -678,7 +678,7 @@ class FunctionsMixin(TranslatorBase):
 
             if is_generator:
                 yield_type = self.coroutine_handler.get_yield_type(node)
-                args_str_list.append(f"ch_out chan ?{yield_type}")
+                args_str_list.append(f"ch_out chan {yield_type}")
                 args_str_list.append(f"ch_in chan PyGeneratorInput")
                 self.coroutine_handler.enter_generator("ch_out", "ch_in")
 

--- a/py2v_transpiler/tests/translator/test_coroutines.py
+++ b/py2v_transpiler/tests/translator/test_coroutines.py
@@ -19,7 +19,7 @@ def gen():
     v_code = translate(py_code)
     # Check for signature change and body
     # It might be indented differently or have comments
-    assert "fn gen(ch_out chan ?int, ch_in chan PyGeneratorInput) {" in v_code
+    assert "fn gen(ch_out chan int, ch_in chan PyGeneratorInput) {" in v_code
     assert "py_yield(ch_out, ch_in, 1)" in v_code
     assert "ch_out.close()" in v_code
 
@@ -31,7 +31,7 @@ def gen(n):
 """
     v_code = translate(py_code)
     # fn gen(ch chan int, n int)
-    assert "fn gen(ch_out chan ?int, ch_in chan PyGeneratorInput, n int) {" in v_code
+    assert "fn gen(ch_out chan int, ch_in chan PyGeneratorInput, n int) {" in v_code
     # Loop checks
     # Range translation: 0..n or similar
     assert "0..n" in v_code or "range(n)" in v_code # V uses 0..n usually
@@ -51,11 +51,11 @@ def main():
     v_code = translate(py_code)
 
     # Check generator def
-    assert "fn gen(ch_out chan ?int, ch_in chan PyGeneratorInput, max int) {" in v_code
+    assert "fn gen(ch_out chan int, ch_in chan PyGeneratorInput, max int) {" in v_code
 
     # Check main
     # Should see channel creation and spawn
-    assert "chan ?int{cap: 0}" in v_code
+    assert "chan int{cap: 0}" in v_code
     assert "spawn gen(" in v_code
     # check that we loop over the channel
     # The channel name is generated, e.g. ch_1
@@ -92,7 +92,7 @@ def gen(a, b):
     yield a + b
 """
     v_code = translate(py_code)
-    assert "fn gen(ch_out chan ?int, ch_in chan PyGeneratorInput, a int, b int) {" in v_code
+    assert "fn gen(ch_out chan int, ch_in chan PyGeneratorInput, a int, b int) {" in v_code
     assert "py_yield(ch_out, ch_in, a + b)" in v_code
 
 def test_generator_with_type_annotation():
@@ -103,7 +103,7 @@ def gen() -> Iterator[str]:
     yield "a"
 """
     v_code = translate(py_code)
-    assert "fn gen(ch_out chan ?string, ch_in chan PyGeneratorInput) {" in v_code
+    assert "fn gen(ch_out chan string, ch_in chan PyGeneratorInput) {" in v_code
     assert "py_yield(ch_out, ch_in, 'a')" in v_code
 
 def test_generator_usage_with_type():
@@ -118,4 +118,4 @@ def main():
         print(x)
 """
     v_code = translate(py_code)
-    assert "chan ?string{cap: 0}" in v_code
+    assert "chan string{cap: 0}" in v_code

--- a/py2v_transpiler/tests/translator/test_generators_slices.py
+++ b/py2v_transpiler/tests/translator/test_generators_slices.py
@@ -20,7 +20,7 @@ def gen():
     # Yield translates to channel push
     assert "py_yield(ch_out, ch_in, 1)" in result
     assert "ch_out.close()" in result
-    assert "fn gen(ch_out chan ?int, ch_in chan PyGeneratorInput) {" in result
+    assert "fn gen(ch_out chan int, ch_in chan PyGeneratorInput) {" in result
 
 def test_translator_list_indexing():
     parser = PyASTParser()

--- a/py2v_transpiler/tests/translator/test_issue_optional_chan.py
+++ b/py2v_transpiler/tests/translator/test_issue_optional_chan.py
@@ -1,0 +1,26 @@
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+def test_generator_optional_chan_issue():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+def my_counter(n: int):
+    for i in range(n):
+        yield i
+
+def test():
+    for num in my_counter(3):
+        print(num)
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    # Check for the valid syntax (no optional ?)
+    assert "ch_out chan int" in result
+    assert "chan int{cap: 0}" in result


### PR DESCRIPTION
The transpiler was incorrectly generating invalid V syntax for channels used in generators by forcing an optional `?` prefix on the element type (e.g., `chan ?int`). In modern V, channels of optional types are not permitted directly. This PR removes that hardcoded prefix from both the function signatures and the call-site initializations, ensuring the generated V code is syntactically correct and compatible with the latest V compiler.

Changes:
- Removed `?` from `ch_out` parameter in `FunctionsMixin`.
- Removed `?` from `ch_out` channel initialization in `CallsMixin`.
- Updated existing coroutine and generator tests to match the valid syntax.
- Added a regression test in `test_issue_optional_chan.py`.

Fixes #273

---
*PR created automatically by Jules for task [6516160624407476105](https://jules.google.com/task/6516160624407476105) started by @yaskhan*