### PR TITLE
Fix missing mutability for 'del' and other mutating operations

### DIFF
--- a/py2v_transpiler/core/analyzer.py
+++ b/py2v_transpiler/core/analyzer.py
@@ -227,7 +227,7 @@ class MixinInferer(ast.NodeVisitor):
 class TypeInference(ast.NodeVisitor):
     def __init__(self):
         self.type_map: Dict[str, str] = {}
-        self.mutability_map: Dict[str, Dict[str, bool]] = {}
+        self.mutability_map: Dict[str, Dict[str, Any]] = {}
         self.location_map: Dict[str, str] = {}
         self.call_signatures: Dict[str, Dict[str, Any]] = {}
         self.mixin_to_main: Dict[str, list[str]] = {}
@@ -257,6 +257,32 @@ class TypeInference(ast.NodeVisitor):
         self.class_methods = mixin_inferer.class_methods
 
         return self.type_map
+
+    def _mark_mutated(self, node: ast.AST):
+        if isinstance(node, ast.Name):
+            name = node.id
+            if name not in self.mutability_map:
+                self.mutability_map[name] = {"is_reassigned": False, "is_final": False, "is_mutated": False}
+            self.mutability_map[name]["is_mutated"] = True
+        elif isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            name = f"{node.value.id}.{node.attr}"
+            if name not in self.mutability_map:
+                self.mutability_map[name] = {"is_reassigned": False, "is_final": False, "is_mutated": False}
+            self.mutability_map[name]["is_mutated"] = True
+
+    def _mark_reassigned(self, node: ast.AST):
+        if isinstance(node, ast.Name):
+            name = node.id
+            if name in self.mutability_map:
+                self.mutability_map[name]["is_reassigned"] = True
+            else:
+                self.mutability_map[name] = {"is_reassigned": False, "is_final": False, "is_mutated": False}
+                # If we see it first time here, it might be the initial assignment.
+                # But NodeVisitor walks the tree.
+                # Usually mypy tracks this better.
+        elif isinstance(node, (ast.Tuple, ast.List)):
+            for elt in node.elts:
+                self._mark_reassigned(elt)
 
     def _guess_node_type(self, node: ast.AST) -> str:
         if isinstance(node, ast.Constant):
@@ -308,20 +334,35 @@ class TypeInference(ast.NodeVisitor):
         return "Any"
 
     def visit_Call(self, node: ast.Call) -> Any:
-        if isinstance(node.func, ast.Attribute) and node.func.attr == "append":
-            if isinstance(node.func.value, ast.Name):
-                var_name = node.func.value.id
-                if len(node.args) == 1:
-                    elt_type = self._guess_node_type(node.args[0])
-                    if elt_type != "Any":
-                        new_type = f"[]{elt_type}"
-                        if var_name not in self.type_map or self.type_map[var_name] == "[]Any":
-                            self.type_map[var_name] = new_type
+        if isinstance(node.func, ast.Attribute):
+            mutating_methods = {
+                "append", "extend", "insert", "pop", "remove", "clear",
+                "update", "setdefault", "delete", "add", "discard"
+            }
+            if node.func.attr in mutating_methods:
+                self._mark_mutated(node.func.value)
+
+            if node.func.attr == "append":
+                if isinstance(node.func.value, ast.Name):
+                    var_name = node.func.value.id
+                    if len(node.args) == 1:
+                        elt_type = self._guess_node_type(node.args[0])
+                        if elt_type != "Any":
+                            new_type = f"[]{elt_type}"
+                            if var_name not in self.type_map or self.type_map[var_name] == "[]Any":
+                                self.type_map[var_name] = new_type
         self.generic_visit(node)
 
     def visit_Assign(self, node: ast.Assign) -> Any:
         for target in node.targets:
+            if isinstance(target, ast.Name):
+                if target.id in self.mutability_map:
+                    self.mutability_map[target.id]["is_reassigned"] = True
+                else:
+                    self.mutability_map[target.id] = {"is_reassigned": False, "is_final": False, "is_mutated": False}
+
             if isinstance(target, ast.Subscript):
+                self._mark_mutated(target.value)
                 dict_name = None
                 if isinstance(target.value, ast.Name):
                     dict_name = target.value.id
@@ -358,6 +399,19 @@ class TypeInference(ast.NodeVisitor):
                     if target.id not in self.type_map or self.type_map[target.id] == "Any":
                         self.type_map[target.id] = inferred
 
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> Any:
+        if isinstance(node.target, (ast.Name, ast.Attribute)):
+            self._mark_reassigned(node.target)
+        elif isinstance(node.target, ast.Subscript):
+            self._mark_mutated(node.target.value)
+        self.generic_visit(node)
+
+    def visit_Delete(self, node: ast.Delete) -> Any:
+        for target in node.targets:
+            if isinstance(target, ast.Subscript):
+                self._mark_mutated(target.value)
         self.generic_visit(node)
 
     def _infer_collection_type(self, node: ast.AST) -> str:

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -386,10 +386,10 @@ class FunctionsMixin(TranslatorBase):
             is_mut = False
             if hasattr(self, 'type_inference') and hasattr(self.type_inference, 'mutability_map'):
                 mut_info = self.type_inference.mutability_map.get(arg_name)
-                # For arguments, we usually check if they are reassigned in the function scope
+                # For arguments, we usually check if they are reassigned or mutated in the function scope
                 # full name for arguments in mypy is usually module.func.arg
                 if mut_info:
-                    is_mut = mut_info.get("is_reassigned", False)
+                    is_mut = mut_info.get("is_reassigned", False) or mut_info.get("is_mutated", False)
 
             mut_prefix = "mut " if is_mut else ""
             args_str_list.append(f"{mut_prefix}{arg_name} {arg_type}")

--- a/py2v_transpiler/core/translator/variables_split/annotations.py
+++ b/py2v_transpiler/core/translator/variables_split/annotations.py
@@ -189,7 +189,7 @@ class AnnotationsMixin(TranslatorBase):
                                         mut_info = self.type_inference.mutability_map.get(v_target)
 
                                     if mut_info:
-                                        is_mut = mut_info.get("is_reassigned", False) and not mut_info.get("is_final", False)
+                                        is_mut = (mut_info.get("is_reassigned", False) or mut_info.get("is_mutated", False)) and not mut_info.get("is_final", False)
 
                                 mut_prefix = "mut " if is_mut else ""
                                 emit_fn(f"{self._indent()}{mut_prefix}{v_target} := {rhs}")

--- a/py2v_transpiler/core/translator/variables_split/assignments.py
+++ b/py2v_transpiler/core/translator/variables_split/assignments.py
@@ -458,7 +458,7 @@ class AssignmentsMixin(TranslatorBase):
                                         mut_info = self.type_inference.mutability_map.get(v_lhs)
 
                                     if mut_info:
-                                        is_mut = mut_info.get("is_reassigned", False) and not mut_info.get("is_final", False)
+                                        is_mut = (mut_info.get("is_reassigned", False) or mut_info.get("is_mutated", False)) and not mut_info.get("is_final", False)
 
                                 # Special handling for buffer protocol: always mutable if bytearray
                                 if not is_mut:
@@ -536,7 +536,7 @@ class AssignmentsMixin(TranslatorBase):
                         mut_info = self.type_inference.mutability_map.get(lhs)
 
                     if mut_info:
-                        is_mut = mut_info.get("is_reassigned", False) and not mut_info.get("is_final", False)
+                        is_mut = (mut_info.get("is_reassigned", False) or mut_info.get("is_mutated", False)) and not mut_info.get("is_final", False)
 
                 mut_prefix = "mut " if is_mut else ""
                 self.output.append(f"{self._indent()}{mut_prefix}{lhs} := {source_expr}")

--- a/py2v_transpiler/tests/test_mutation_tracking.py
+++ b/py2v_transpiler/tests/test_mutation_tracking.py
@@ -1,0 +1,62 @@
+
+import textwrap
+import ast
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+class TestMutationTracking:
+    def _transpile(self, python_code):
+        python_code = textwrap.dedent(python_code).strip()
+        parser = PyASTParser()
+        analyzer = TypeInference()
+        tree = parser.parse(python_code)
+        analyzer.analyze(tree)
+        translator = VNodeVisitor(analyzer)
+        return translator.visit_Module(tree)
+
+    def test_dict_del_mutability(self):
+        code = """
+        def foo():
+            d = {'a': 1}
+            del d['a']
+        """
+        result = self._transpile(code)
+        assert "mut d := map[string]int{'a': 1}" in result
+
+    def test_dict_subscript_assign_mutability(self):
+        code = """
+        def foo():
+            d = {}
+            d['a'] = 1
+        """
+        result = self._transpile(code)
+        assert "mut d := map[string]int{}" in result
+
+    def test_list_append_mutability(self):
+        code = """
+        def foo():
+            l = [1]
+            l.append(2)
+        """
+        # Note: current implementation might use cap: 1 initialization
+        result = self._transpile(code)
+        assert "mut l :=" in result
+        assert "l.append(2)" in result
+
+    def test_aug_assign_mutability(self):
+        code = """
+        def foo():
+            x = 1
+            x += 1
+        """
+        result = self._transpile(code)
+        assert "mut x := 1" in result
+
+    def test_param_mutation(self):
+        code = """
+        def foo(d: dict):
+            d['a'] = 1
+        """
+        result = self._transpile(code)
+        assert "fn foo(mut d map[string]int)" in result or "fn foo(mut d map[string]Any)" in result


### PR DESCRIPTION
This change fixes an issue where the transpiler failed to mark variables as mutable (`mut`) when they were modified via `del` statements (e.g., `del d['key']`).
Additionally, it improves mutation tracking for:
- Subscript assignments (e.g., `d['key'] = value`)
- Common mutating methods (e.g., `pop()`, `update()`, `clear()`, `remove()`, `insert()`)
- Augmented assignments (e.g., `x += 1`)
- Function parameters that are mutated within the function body.

The fix involves enhancing the `TypeInference` analyzer to track these operations in a `mutability_map` and updating the translation logic in `AssignmentsMixin`, `AnnotationsMixin`, and `FunctionsMixin` to correctly emit the `mut` prefix in V.

Fixes #300

---
*PR created automatically by Jules for task [6397596238890756645](https://jules.google.com/task/6397596238890756645) started by @yaskhan*