### PR TITLE
Fix Global Variable Syntax Error

### DIFF
--- a/py2v_transpiler/core/generator.py
+++ b/py2v_transpiler/core/generator.py
@@ -80,9 +80,13 @@ class VCodeEmitter:
             lines.append("")
 
         if self.globals:
-            lines.append("__global (")
-            lines.extend(["    " + g for g in self.globals])
-            lines.append(")\n")
+            lines.insert(1, "// To compile with globals, use: v -enable-globals .")
+            for g in self.globals:
+                sanitized_g = g
+                if g.startswith("pub "):
+                    sanitized_g = g[4:]
+                lines.append(f"__global {sanitized_g}")
+            lines.append("")
 
         if self.constants:
             lines.append("const (")

--- a/py2v_transpiler/core/translator/variables_split/assignments.py
+++ b/py2v_transpiler/core/translator/variables_split/assignments.py
@@ -396,34 +396,33 @@ class AssignmentsMixin(TranslatorBase):
                         if isinstance(target, ast.Name):
                             if v_type == "unknown":
                                 v_type = "Any"
-                            pub = "pub " if self._is_exported(target.id) else ""
-                            self.emitter.add_global(f"{pub}{lhs} {v_type}")
+                            self.emitter.add_global(f"{lhs} {v_type}")
                     elif base_lhs.isupper():
                         emit_fn = lambda stmt: self.emitter.add_init_statement(stmt.strip())
                         if isinstance(target, ast.Name):
                             v_lhs = self._to_snake_case(lhs)
-                            pub = "pub " if self._is_exported(target.id) else ""
                             if self._is_compile_time_evaluable(node.value):
                                 # Compile-time constant (e.g. DEFAULT_WIDTH = 100) -> const block
+                                pub = "pub " if self._is_exported(target.id) else ""
                                 self.emitter.add_constant(f"{pub}{v_lhs} = {rhs}")
                                 return
                             else:
                                 # Runtime UPPER_CASE (e.g. Vector_ZERO = new_Vector(...)) -> global + init()
                                 if v_type == "unknown" or v_type == "int":
                                     v_type = "Any"
-                                self.emitter.add_global(f"{pub}{v_lhs} {v_type}")
+                                self.emitter.add_global(f"{v_lhs} {v_type}")
                                 lhs = v_lhs
 
                 if self.in_main and isinstance(target, ast.Name) and (lhs in getattr(self, "global_vars", set()) or lhs.isupper() or is_implicit_literal or is_literal_string):
                     v_lhs = self._to_snake_case(lhs) if not lhs.islower() else lhs
                     # For compile-time constants we already returned above - assignment not needed
-                    pub = "pub " if self._is_exported(target.id) else ""
                     if (is_implicit_literal or is_literal_string) and self._is_compile_time_evaluable(node.value) and not lhs.isupper():
+                        pub = "pub " if self._is_exported(target.id) else ""
                         self.emitter.add_constant(f"{pub}{v_lhs} = {rhs}")
                         return
                     if (is_implicit_literal or is_literal_string) and not self._is_compile_time_evaluable(node.value) and not lhs.isupper():
                         if lhs not in getattr(self, "global_vars", set()):
-                            self.emitter.add_global(f"{pub}{v_lhs} string")
+                            self.emitter.add_global(f"{v_lhs} string")
                         self.emitter.add_init_statement(f"{v_lhs} = {rhs}")
                         return
                     if not (lhs.isupper() and self._is_compile_time_evaluable(node.value)):

--- a/py2v_transpiler/tests/test_generator.py
+++ b/py2v_transpiler/tests/test_generator.py
@@ -89,8 +89,7 @@ def test_emit_basic():
     assert "module main" in code
     assert "import os" in code
     assert "struct Point {" in code
-    assert "__global (" in code
-    assert "    g int" in code
+    assert "__global g int" in code
     assert "const (" in code
     assert "    C = 1" in code
     assert "fn foo() {}" in code

--- a/py2v_transpiler/tests/translator/test_global_constants.py
+++ b/py2v_transpiler/tests/translator/test_global_constants.py
@@ -38,8 +38,7 @@ Vector_ZERO: Final = Vector(0, 0, 0)
 """
     v_code = translate(source)
     # Because Vector is not compile time evaluable, it should be in __global and initialized in init()
-    assert "__global (" in v_code
-    assert "vector_zero Any" in v_code
+    assert "__global vector_zero Any" in v_code
 
     assert "fn init() {" in v_code
     assert "vector_zero = Vector(0, 0, 0)" in v_code
@@ -54,8 +53,7 @@ VECTOR_ONE = Vector(1, 1, 1)
 """
     v_code = translate(source)
     # Uppercase but runtime initialization
-    assert "__global (" in v_code
-    assert "vector_one Any" in v_code
+    assert "__global vector_one Any" in v_code
 
     assert "fn init() {" in v_code
     assert "vector_one = Vector(1, 1, 1)" in v_code


### PR DESCRIPTION
This change updates the transpiler to emit valid V global variable syntax by removing block parentheses and the 'pub' keyword from __global declarations. It also adds a compilation hint for the -enable-globals flag and cleans up unused variables in AssignmentsMixin.

Fixes #297

---
*PR created automatically by Jules for task [9041270690037693785](https://jules.google.com/task/9041270690037693785) started by @yaskhan*