### PR TITLE
Fix Context Manager Transpilation to V

### DIFF
--- a/py2v_transpiler/core/generator.py
+++ b/py2v_transpiler/core/generator.py
@@ -120,7 +120,7 @@ class VCodeEmitter:
         lines = [f"module {module_name}\n"]
 
         # Define custom Any type
-        lines.append("type Any = bool | int | i64 | f64 | string | []u8\n")
+        lines.append("pub type Any = bool | int | i64 | f64 | string | []u8 | none\n")
 
         # Sort and deduplicate imports
         unique_imports = sorted(list(set(imports)))

--- a/py2v_transpiler/core/translator/control_flow_split/context.py
+++ b/py2v_transpiler/core/translator/control_flow_split/context.py
@@ -5,19 +5,20 @@ class ContextMixin(TranslatorBase):
     """Обработка контекстных менеджеров: with, async with"""
     
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
-        # Similar logic to visit_With, assuming mapped V types support .close()
+        # Similar logic to visit_With, but using enter/exit
         for item in node.items:
             context_expr = self.visit(item.context_expr)
 
+            tmp_var = f"ctx_mgr_{self._zip_counter}"
+            self._zip_counter += 1
+            self.output.append(f"{self._indent()}{tmp_var} := {context_expr}")
+            self.output.append(f"{self._indent()}defer {{ {tmp_var}.exit(none, none, none) }}")
+
             if item.optional_vars:
                 var = self.visit(item.optional_vars)
-                self.output.append(f"{self._indent()}{var} := {context_expr}")
-                self.output.append(f"{self._indent()}defer {{ {var}.close() }}")
+                self.output.append(f"{self._indent()}{var} := {tmp_var}.enter()")
             else:
-                tmp_var = f"_ctx_mgr_{self._zip_counter}"
-                self._zip_counter += 1
-                self.output.append(f"{self._indent()}{tmp_var} := {context_expr}")
-                self.output.append(f"{self._indent()}defer {{ {tmp_var}.close() }}")
+                self.output.append(f"{self._indent()}{tmp_var}.enter()")
 
         for stmt in node.body:
             self.visit(stmt)
@@ -28,6 +29,8 @@ class ContextMixin(TranslatorBase):
             # Check if context_expr is a call to these functions
             is_nullcontext = False
             is_suppress = False
+            is_legacy_mgr = False # Use .close() instead of .enter()/.exit()
+
             if isinstance(item.context_expr, ast.Call):
                 func = item.context_expr.func
 
@@ -41,10 +44,13 @@ class ContextMixin(TranslatorBase):
                          full_name = self.imported_symbols[func.id]
                          if full_name == "contextlib.nullcontext": is_nullcontext = True
                          if full_name == "contextlib.suppress": is_suppress = True
+                         if full_name == "contextlib.closing": is_legacy_mgr = True
                     else:
                          # Heuristic for unimported or simple usage
                          if func.id == "nullcontext": is_nullcontext = True
                          if func.id == "suppress": is_suppress = True
+                         if func.id == "open": is_legacy_mgr = True
+                         if func.id == "closing": is_legacy_mgr = True
 
                 elif isinstance(func, ast.Attribute):
                     # contextlib.nullcontext
@@ -56,6 +62,7 @@ class ContextMixin(TranslatorBase):
                         if resolved_module == "contextlib":
                             if attr_name == "nullcontext": is_nullcontext = True
                             if attr_name == "suppress": is_suppress = True
+                            if attr_name == "closing": is_legacy_mgr = True
 
             context_expr = self.visit(item.context_expr)
 
@@ -67,7 +74,7 @@ class ContextMixin(TranslatorBase):
 
             if is_nullcontext:
                 # nullcontext(x) maps to x.
-                # We assign it to var if present, but do NOT defer close()
+                # We assign it to var if present, but do NOT defer exit()
                 if item.optional_vars:
                     var = self.visit(item.optional_vars)
                     self.output.append(f"{self._indent()}{var} := {context_expr}")
@@ -75,16 +82,27 @@ class ContextMixin(TranslatorBase):
                     self.output.append(f"{self._indent()}_ = {context_expr}")
                 continue
 
+            if is_legacy_mgr:
+                if item.optional_vars:
+                    var = self.visit(item.optional_vars)
+                    self.output.append(f"{self._indent()}{var} := {context_expr}")
+                    self.output.append(f"{self._indent()}defer {{ {var}.close() }}")
+                else:
+                    tmp_var = f"ctx_mgr_{self._zip_counter}"
+                    self._zip_counter += 1
+                    self.output.append(f"{self._indent()}{tmp_var} := {context_expr}")
+                    self.output.append(f"{self._indent()}defer {{ {tmp_var}.close() }}")
+                continue
+
+            tmp_var = f"ctx_mgr_{self._zip_counter}"
+            self._zip_counter += 1
+            self.output.append(f"{self._indent()}{tmp_var} := {context_expr}")
+            self.output.append(f"{self._indent()}defer {{ {tmp_var}.exit(none, none, none) }}")
+
             if item.optional_vars:
                 var = self.visit(item.optional_vars)
-                self.output.append(f"{self._indent()}{var} := {context_expr}")
-                self.output.append(f"{self._indent()}defer {{ {var}.close() }}")
+                self.output.append(f"{self._indent()}{var} := {tmp_var}.enter()")
             else:
-                # If no variable is assigned, we still need to close it.
-                # But we don't have a variable name. We should create a temp one.
-                tmp_var = f"_ctx_mgr_{self._zip_counter}"
-                self._zip_counter += 1
-                self.output.append(f"{self._indent()}{tmp_var} := {context_expr}")
-                self.output.append(f"{self._indent()}defer {{ {tmp_var}.close() }}")
+                self.output.append(f"{self._indent()}{tmp_var}.enter()")
         for stmt in node.body:
             self.visit(stmt)

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -373,9 +373,11 @@ class FunctionsMixin(TranslatorBase):
                     self._check_experimental_type(type_str, arg.annotation)
                     arg_type = self._map_type(type_str, struct_name)
                 except Exception:
-                    arg_type = self._map_type(self.type_inference.type_map.get(arg_name, "int"), struct_name)
+                    default_type = "Any" if node.name == "__exit__" else "int"
+                    arg_type = self._map_type(self.type_inference.type_map.get(arg_name, default_type), struct_name)
             else:
-                arg_type = self._map_type(self.type_inference.type_map.get(arg_name, "int"), struct_name)
+                default_type = "Any" if node.name == "__exit__" else "int"
+                arg_type = self._map_type(self.type_inference.type_map.get(arg_name, default_type), struct_name)
 
             # In stubs, skip parameters that map to void (NoReturn)
             if (is_stub_function or self.current_file_name.endswith('.pyi')) and arg_type == "void":
@@ -433,6 +435,12 @@ class FunctionsMixin(TranslatorBase):
                     node.returns.value, str
                 ):
                     ret_type = node.returns.value
+        elif not is_generator and not node.returns and node.name == "__enter__":
+            # Infer return type for __enter__ (enter) if missing
+            for body_stmt in node.body:
+                if isinstance(body_stmt, ast.Return) and isinstance(body_stmt.value, ast.Name) and body_stmt.value.id == "self":
+                    ret_type = self._get_full_self_type(struct_name)
+                    break
 
         # Check for NoReturn
         is_noreturn = False
@@ -458,6 +466,10 @@ class FunctionsMixin(TranslatorBase):
 
             if func_name == "__next__":
                 func_name = "next"
+            elif func_name in ("__enter__", "__aenter__"):
+                func_name = "enter"
+            elif func_name in ("__exit__", "__aexit__"):
+                func_name = "exit"
             elif func_name == "__post_init__":
                 func_name = "post_init"
             elif func_name == "__await__":

--- a/py2v_transpiler/tests/translator/test_async_with.py
+++ b/py2v_transpiler/tests/translator/test_async_with.py
@@ -21,9 +21,10 @@ async def foo():
         pass
 """
         result = self.transpile(source)
-        # Expect 'x := mgr' and 'defer { x.close() }'
-        self.assertIn("x := mgr", result)
-        self.assertIn("defer { x.close() }", result)
+        # Expect temp mgr, defer exit, and x := enter
+        self.assertIn("ctx_mgr_0 := mgr", result)
+        self.assertIn("defer { ctx_mgr_0.exit(none, none, none) }", result)
+        self.assertIn("x := ctx_mgr_0.enter()", result)
 
     def test_async_with_no_var(self):
         source = """
@@ -34,7 +35,7 @@ async def foo():
         result = self.transpile(source)
         # Expect temp var and defer
         self.assertIn("defer {", result)
-        self.assertIn(".close() }", result)
+        self.assertIn(".exit(none, none, none) }", result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/py2v_transpiler/tests/translator/test_decimal.py
+++ b/py2v_transpiler/tests/translator/test_decimal.py
@@ -38,7 +38,8 @@ def calc():
         d = decimal.Decimal("3.14159")
 """
     v_code = translate(source)
-    assert "ctx := py_decimal_localcontext()" in v_code
-    assert "defer { ctx.close() }" in v_code
+    assert "ctx_mgr_0 := py_decimal_localcontext()" in v_code
+    assert "ctx := ctx_mgr_0.enter()" in v_code
+    assert "defer { ctx_mgr_0.exit(none, none, none) }" in v_code
     assert "ctx.prec = 50" in v_code
     assert "py_decimal_getcontext().prec = 50" in v_code

--- a/py2v_transpiler/tests/translator/test_exceptions_context.py
+++ b/py2v_transpiler/tests/translator/test_exceptions_context.py
@@ -37,6 +37,7 @@ with open("file.txt") as f:
     result = translator.visit_Module(tree)
 
     # open is mapped to os.open
-    assert 'f := os.open("file.txt")' in result.replace("'", '"')
+    assert 'os.open("file.txt")' in result.replace("'", '"')
     assert "defer { f.close() }" in result
+    assert "f := os.open" in result.replace("'", '"')
     assert "println('${f.read()}')" in result

--- a/py2v_transpiler/tests/translator/test_todo_features.py
+++ b/py2v_transpiler/tests/translator/test_todo_features.py
@@ -63,10 +63,12 @@ class TestTodoFeatures(TranspilerTest):
                 pass
             """,
             """
-            a := A()
-            defer { a.close() }
-            b := B()
-            defer { b.close() }
+            ctx_mgr_0 := A()
+            defer { ctx_mgr_0.exit(none, none, none) }
+            a := ctx_mgr_0.enter()
+            ctx_mgr_1 := B()
+            defer { ctx_mgr_1.exit(none, none, none) }
+            b := ctx_mgr_1.enter()
             """
         )
 


### PR DESCRIPTION
This change fixes the transpilation of Python context managers to V. It renames dunder methods `__enter__` and `__exit__` to valid V method names and correctly structures `with` blocks to manage the context manager's lifecycle, while preserving compatibility for built-in types like files.

Fixes #298

---
*PR created automatically by Jules for task [10500658975897593746](https://jules.google.com/task/10500658975897593746) started by @yaskhan*