### PR TITLE
Expand Pydantic Field Constraint Support

### DIFF
--- a/py2v_transpiler/pydantic_support/field_processor.py
+++ b/py2v_transpiler/pydantic_support/field_processor.py
@@ -15,6 +15,17 @@ class PydanticFieldInfo:
     max_length: Optional[str] = None
     min_length: Optional[str] = None
     is_optional: bool = False
+    pattern: Optional[str] = None
+    multiple_of: Optional[str] = None
+    min_items: Optional[str] = None
+    max_items: Optional[str] = None
+    unique_items: bool = False
+    const: Optional[str] = None
+    description: Optional[str] = None
+    title: Optional[str] = None
+    examples: Optional[str] = None
+    repr: bool = True
+    exclude: bool = False
 
 class PydanticFieldProcessor:
     def __init__(self, visitor: Any):
@@ -74,12 +85,45 @@ class PydanticFieldProcessor:
                 info.max_length = val
             elif keyword.arg == "min_length":
                 info.min_length = val
+            elif keyword.arg in ("pattern", "regex"):
+                info.pattern = val
+            elif keyword.arg == "multiple_of":
+                info.multiple_of = val
+            elif keyword.arg == "min_items":
+                info.min_items = val
+            elif keyword.arg == "max_items":
+                info.max_items = val
+            elif keyword.arg == "unique_items":
+                info.unique_items = val == "true"
+            elif keyword.arg == "const":
+                info.const = val
+            elif keyword.arg == "description":
+                if val.startswith("'") or val.startswith('"'):
+                    val = val[1:-1]
+                info.description = val
+            elif keyword.arg == "title":
+                if val.startswith("'") or val.startswith('"'):
+                    val = val[1:-1]
+                info.title = val
+            elif keyword.arg == "examples":
+                info.examples = val
+            elif keyword.arg == "repr":
+                info.repr = val == "true"
+            elif keyword.arg == "exclude":
+                info.exclude = val == "true"
 
     def generate_struct_tags(self, info: PydanticFieldInfo) -> str:
         """Generates Vlang struct tags like [json: 'alias']."""
         tags = []
-        if info.alias:
+        if info.exclude:
+            tags.append("json: '-'")
+        elif info.alias:
             tags.append(f"json: '{info.alias}'")
+
+        if info.description:
+            tags.append(f"description: '{info.description}'")
+        if info.title:
+            tags.append(f"title: '{info.title}'")
 
         if tags:
              return f"[{'; '.join(tags)}]"
@@ -119,6 +163,38 @@ class PydanticFieldProcessor:
              code.append(f"{indent}if {prefix}.len > {info.max_length} {{ return error('Validation Error: {info.name} length must be <= {info.max_length}') }}")
         if info.min_length:
              code.append(f"{indent}if {prefix}.len < {info.min_length} {{ return error('Validation Error: {info.name} length must be >= {info.min_length}') }}")
+
+        if info.pattern:
+            code.append(f"{indent}if !regex.match({prefix}, {info.pattern}) {{ return error('Validation Error: {info.name} must match pattern') }}")
+
+        if info.multiple_of:
+            code.append(f"{indent}if {prefix} % {info.multiple_of} != 0 {{ return error('Validation Error: {info.name} must be multiple of {info.multiple_of}') }}")
+
+        if info.min_items:
+            code.append(f"{indent}if {prefix}.len < {info.min_items} {{ return error('Validation Error: {info.name} length must be >= {info.min_items}') }}")
+        if info.max_items:
+            code.append(f"{indent}if {prefix}.len > {info.max_items} {{ return error('Validation Error: {info.name} length must be <= {info.max_items}') }}")
+
+        if info.unique_items:
+            item_type = info.type_str
+            if item_type.startswith("[]"):
+                item_type = item_type[2:]
+            elif item_type.startswith("map[") and "]bool" in item_type:
+                # set[T] is map[T]bool
+                item_type = item_type[4:item_type.find("]bool")]
+
+            code.append(f"{indent}seen_{info.name} := map[{item_type}]bool{{}}")
+            code.append(f"{indent}for item in {prefix} {{")
+            code.append(f"{indent}    if item in seen_{info.name} {{ return error('Validation Error: {info.name} items must be unique') }}")
+            code.append(f"{indent}    seen_{info.name}[item] = true")
+            code.append(f"{indent}}}")
+
+        if info.const:
+            const_display = info.const
+            if (const_display.startswith("'") and const_display.endswith("'")) or \
+               (const_display.startswith('"') and const_display.endswith('"')):
+                const_display = const_display[1:-1]
+            code.append(f"{indent}if {prefix} != {info.const} {{ return error('Validation Error: {info.name} must be {const_display}') }}")
 
         if info.is_optional:
             code.append("    }")

--- a/py2v_transpiler/pydantic_support/model_processor.py
+++ b/py2v_transpiler/pydantic_support/model_processor.py
@@ -23,6 +23,12 @@ class PydanticModelProcessor:
                 # Will handle validators in validator_processor
                 methods.append(item)
 
+        # Check if we need to add imports
+        for field in fields:
+            if field.pattern:
+                self.visitor.emitter.add_import("regex")
+                break
+
         # Generate Struct
         export = "pub " if self.visitor._is_exported(struct_name) else ""
 

--- a/py2v_transpiler/tests/translator/test_pydantic.py
+++ b/py2v_transpiler/tests/translator/test_pydantic.py
@@ -52,3 +52,40 @@ class Item(BaseModel):
         self.assertIn("price ?f64", v_code)
         self.assertIn("if m.price != none {", v_code)
         self.assertIn("if m.price? <= 0.0 {", v_code)
+
+    def test_extended_field_constraints(self):
+        code = """
+from pydantic import BaseModel, Field
+from typing import List
+
+class Product(BaseModel):
+    sku: str = Field(pattern=r'^[A-Z]{3}-\d{4}$', title='Stock Keeping Unit', description='A unique SKU')
+    price: float = Field(multiple_of=0.01)
+    tags: List[str] = Field(min_items=1, max_items=10, unique_items=True)
+    category: str = Field(const='electronics', exclude=True)
+"""
+        v_code = self.translate(code)
+
+        # Check struct and tags
+        self.assertIn("sku string [description: 'A unique SKU'; title: 'Stock Keeping Unit']", v_code)
+        self.assertIn("price f64", v_code)
+        self.assertIn("tags []string", v_code)
+        self.assertIn("category string [json: '-']", v_code)
+
+        # Check imports
+        self.assertIn("import regex", v_code)
+
+        # Check validation logic
+        self.assertIn("if !regex.match(m.sku, r'^[A-Z]{3}-\\d{4}$') { return error('Validation Error: sku must match pattern') }", v_code)
+        self.assertIn("if m.price % 0.01 != 0 { return error('Validation Error: price must be multiple of 0.01') }", v_code)
+        self.assertIn("if m.tags.len < 1 { return error('Validation Error: tags length must be >= 1') }", v_code)
+        self.assertIn("if m.tags.len > 10 { return error('Validation Error: tags length must be <= 10') }", v_code)
+
+        # Check uniqueness loop
+        self.assertIn("seen_tags := map[string]bool{}", v_code)
+        self.assertIn("for item in m.tags {", v_code)
+        self.assertIn("if item in seen_tags { return error('Validation Error: tags items must be unique') }", v_code)
+        self.assertIn("seen_tags[item] = true", v_code)
+
+        # Check const
+        self.assertIn("if m.category != 'electronics' { return error('Validation Error: category must be electronics') }", v_code)


### PR DESCRIPTION
This change expands the Pydantic Field constraint support in the Python-to-V transpiler. 

Key improvements:
- **Validation**: The transpiler now generates V validation code for `pattern` (regex), `multiple_of`, `min_items`, `max_items`, `unique_items`, and `const`.
- **Metadata**: Support for `description`, `title`, and `exclude` has been added, generating appropriate Vlang struct tags.
- **Imports**: The V `regex` module is now automatically imported if any field in a model uses a `pattern` constraint.
- **Robustness**: Handling of collection types (lists and sets) for uniqueness checks has been implemented with dynamic type detection.

Verified with a new comprehensive test case and by running the full project test suite (599 tests), all of which passed.

Fixes #286

---
*PR created automatically by Jules for task [14386889014527401021](https://jules.google.com/task/14386889014527401021) started by @yaskhan*