### PR TITLE
Fix list.append() translation to use V push operator <<

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -668,9 +668,15 @@ class CallsMixin(TranslatorBase):
             obj_str = self._visit_with_parens(dummy_attr, node.args[0])
             return f"{obj_str}.len"
 
-        if isinstance(func_node, ast.Attribute) and func_node.attr == "clear" and not module_name:
-             obj = self.visit(func_node.value)
-             return f"/* {obj}.clear() */ {obj} = {{}}"
+        if isinstance(func_node, ast.Attribute) and not module_name:
+            if func_node.attr == "append" and len(args) == 1:
+                obj_type = self._guess_type(func_node.value)
+                if obj_type.startswith("[]") or obj_type == "Any":
+                    obj = self.visit(func_node.value)
+                    return f"{obj} << {args[0]}"
+            elif func_node.attr == "clear":
+                obj = self.visit(func_node.value)
+                return f"/* {obj}.clear() */ {obj} = {{}}"
 
         # Handle list.sort(reverse=True)
         if isinstance(func_node, ast.Attribute) and func_node.attr == "sort":

--- a/py2v_transpiler/tests/test_mutation_tracking.py
+++ b/py2v_transpiler/tests/test_mutation_tracking.py
@@ -42,7 +42,7 @@ class TestMutationTracking:
         # Note: current implementation might use cap: 1 initialization
         result = self._transpile(code)
         assert "mut l :=" in result
-        assert "l.append(2)" in result
+        assert "l << 2" in result
 
     def test_aug_assign_mutability(self):
         code = """


### PR DESCRIPTION
The Python-to-V transpiler was incorrectly translating `list.append(item)` calls directly to `list.append(item)` in V, which is invalid as V arrays use the `<<` operator for appending. 

This change:
1. Modifies `CallsMixin.visit_Call` in `py2v_transpiler/core/translator/expressions_split/calls.py` to intercept `.append()` calls.
2. Uses type inference to ensure the receiver is a list (`[]T`) or `Any` before applying the translation.
3. Translates `obj.append(val)` to `obj << val`.
4. Updates the corresponding test case in `py2v_transpiler/tests/test_mutation_tracking.py`.
5. Ensures all 612 existing tests pass.

Fixes #317

---
*PR created automatically by Jules for task [6650227344356872229](https://jules.google.com/task/6650227344356872229) started by @yaskhan*