### PR TITLE
Implement Pydantic Validator Decorators

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -133,6 +133,7 @@ class TranslatorBase(ast.NodeVisitor):
         self.warnings: List[str] = []
         self.type_vars: Set[str] = set()
         self.current_function_return_type: Optional[str] = None
+        self.in_pydantic_validator: bool = False
 
     def _is_literal_string_expr(self, node: ast.AST) -> bool:
         """

--- a/py2v_transpiler/core/translator/control_flow_split/exceptions.py
+++ b/py2v_transpiler/core/translator/control_flow_split/exceptions.py
@@ -6,6 +6,22 @@ class ExceptionsMixin(TranslatorBase):
     """Обработка исключений: try, except, raise, finally"""
     
     def visit_Raise(self, node: ast.Raise) -> None:
+        if self.in_pydantic_validator:
+            if node.exc:
+                if isinstance(node.exc, ast.Call):
+                    msg = ""
+                    if node.exc.args:
+                        msg = self.visit(node.exc.args[0])
+                    self.output.append(f"{self._indent()}return error({msg})")
+                elif isinstance(node.exc, ast.Name):
+                    self.output.append(f"{self._indent()}return error('{node.exc.id}')")
+                else:
+                    val = self.visit(node.exc)
+                    self.output.append(f"{self._indent()}return error('${{{val}}}')")
+            else:
+                self.output.append(f"{self._indent()}return error('Validation Error')")
+            return
+
         self.emitter.add_import('div72.vexc')
         if node.exc:
             if isinstance(node.exc, ast.Call):

--- a/py2v_transpiler/pydantic_support/model_processor.py
+++ b/py2v_transpiler/pydantic_support/model_processor.py
@@ -31,7 +31,8 @@ class PydanticModelProcessor:
                 v_info = self.validator_processor.extract_info(item)
                 if v_info:
                     validators.append(v_info)
-                methods.append(item)
+                else:
+                    methods.append(item)
             elif PydanticDetector.is_config_class(item):
                 config = self.config_processor.extract(item)
             elif isinstance(item, ast.Assign):
@@ -164,15 +165,18 @@ class PydanticModelProcessor:
         # 1. Model validators (mode='before')
         for v in validators:
             if v.is_model_validator and v.mode == 'before':
-                has_validation = True
-                code.append(f"    m.{v.name}()")
+                v_logic = self._generate_validator_logic(v, struct_name, fields)
+                if v_logic:
+                    has_validation = True
+                    code.extend(v_logic)
 
         # 2. Field validators (mode='before')
         for v in validators:
             if not v.is_model_validator and v.mode == 'before':
-                has_validation = True
-                for f_name in v.fields:
-                    code.append(f"    m.{f_name} = {struct_name}_{v.name}(m.{f_name})")
+                v_logic = self._generate_validator_logic(v, struct_name, fields)
+                if v_logic:
+                    has_validation = True
+                    code.extend(v_logic)
 
         # 3. Built-in field constraints
         for field_info in fields:
@@ -184,23 +188,97 @@ class PydanticModelProcessor:
         # 4. Field validators (mode='after' or default)
         for v in validators:
             if not v.is_model_validator and (v.mode in ('after', 'default') or not v.mode):
-                has_validation = True
-                for f_name in v.fields:
-                    # If it's a classmethod validator, it's called as Struct_name_validator(value)
-                    # We assume it returns the validated value
-                    code.append(f"    m.{f_name} = {struct_name}_{v.name}(m.{f_name})")
+                v_logic = self._generate_validator_logic(v, struct_name, fields)
+                if v_logic:
+                    has_validation = True
+                    code.extend(v_logic)
 
         # 5. Model validators (mode='after' or default)
         for v in validators:
             if v.is_model_validator and (v.mode in ('after', 'default') or not v.mode):
-                has_validation = True
-                code.append(f"    m.{v.name}()")
+                v_logic = self._generate_validator_logic(v, struct_name, fields)
+                if v_logic:
+                    has_validation = True
+                    code.extend(v_logic)
 
         if not has_validation and not (config and config.validate_all):
             return ""
 
         code.append("}")
         return "\n".join(code)
+
+    def _generate_validator_logic(self, v_info: PydanticValidatorInfo, struct_name: str, fields: List[PydanticFieldInfo]) -> List[str]:
+        node = v_info.node
+        if not node:
+            return []
+
+        res = []
+        field_map = {f.name: f for f in fields}
+
+        # Save visitor state
+        old_output = self.visitor.output
+        old_indent = self.visitor._indent_level
+        old_in_validator = self.visitor.in_pydantic_validator
+        old_remap = self.visitor.name_remap.copy()
+        old_ret_type = getattr(self.visitor, 'current_function_return_type', None)
+
+        self.visitor.in_pydantic_validator = True
+        self.visitor._indent_level = 2
+
+        try:
+            if v_info.is_model_validator:
+                res.append(f"    m = fn (mut self {struct_name}) !{struct_name} {{")
+                self.visitor.output = []
+                self.visitor.current_function_return_type = struct_name
+
+                real_args = node.args.args
+                if real_args:
+                    self.visitor.name_remap[real_args[0].arg] = "self"
+
+                body = node.body
+                if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
+                    body = body[1:]
+
+                for stmt in body:
+                    self.visitor.visit(stmt)
+
+                for line in self.visitor.output:
+                    res.append(line)
+                res.append("    }(mut m) !")
+            else:
+                for f_name in v_info.fields:
+                    f_info = field_map.get(f_name)
+                    f_type = f_info.type_str if f_info else "Any"
+
+                    res.append(f"    m.{f_name} = fn (v {f_type}) !{f_type} {{")
+                    self.visitor.output = []
+                    self.visitor.current_function_return_type = f_type
+
+                    real_args = node.args.args
+                    if real_args and real_args[0].arg in ('cls', 'self'):
+                        real_args = real_args[1:]
+
+                    if real_args:
+                        self.visitor.name_remap[real_args[0].arg] = "v"
+
+                    body = node.body
+                    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
+                        body = body[1:]
+
+                    for stmt in body:
+                        self.visitor.visit(stmt)
+
+                    for line in self.visitor.output:
+                        res.append(line)
+                    res.append(f"    }}(m.{f_name}) !")
+        finally:
+            self.visitor.output = old_output
+            self.visitor._indent_level = old_indent
+            self.visitor.in_pydantic_validator = old_in_validator
+            self.visitor.name_remap = old_remap
+            self.visitor.current_function_return_type = old_ret_type
+
+        return res
 
     def _generate_factory_method(self, struct_name: str, fields: List[PydanticFieldInfo], export: str) -> str:
         """Generates a new_StructName factory function."""

--- a/py2v_transpiler/pydantic_support/validator_processor.py
+++ b/py2v_transpiler/pydantic_support/validator_processor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 class PydanticValidatorInfo:
     name: str
     fields: List[str]
+    node: Optional[ast.FunctionDef | ast.AsyncFunctionDef] = None
     mode: str = "after" # 'before', 'after', 'wrap', 'plain'
     is_model_validator: bool = False
 
@@ -49,17 +50,26 @@ class PydanticValidatorProcessor:
                     val = dec_keywords["mode"]
                     if isinstance(val, ast.Constant) and isinstance(val.value, str):
                         mode = val.value
+                elif "pre" in dec_keywords:
+                    val = dec_keywords["pre"]
+                    if isinstance(val, ast.Constant) and val.value is True:
+                        mode = "before"
+
             elif dec_name in ("model_validator", "root_validator"):
                 is_model_validator = True
                 if "mode" in dec_keywords:
                     val = dec_keywords["mode"]
                     if isinstance(val, ast.Constant) and isinstance(val.value, str):
                         mode = val.value
+                elif "pre" in dec_keywords:
+                    val = dec_keywords["pre"]
+                    if isinstance(val, ast.Constant) and val.value is True:
+                        mode = "before"
 
         if is_field_validator:
-            return PydanticValidatorInfo(name=node.name, fields=fields, mode=mode, is_model_validator=False)
+            return PydanticValidatorInfo(name=node.name, fields=fields, node=node, mode=mode, is_model_validator=False)
         if is_model_validator:
-            return PydanticValidatorInfo(name=node.name, fields=[], mode=mode, is_model_validator=True)
+            return PydanticValidatorInfo(name=node.name, fields=[], node=node, mode=mode, is_model_validator=True)
 
         return None
 

--- a/py2v_transpiler/tests/translator/test_pydantic_v2.py
+++ b/py2v_transpiler/tests/translator/test_pydantic_v2.py
@@ -50,7 +50,9 @@ class User(BaseModel):
         self.assertIn('if m.name.len < 2 { return error("Validation Error: name length must be >= 2")', v_code)
 
         # Check field_validator integration
-        self.assertIn("m.email = User_validate_email(m.email)", v_code)
+        self.assertIn("m.email = fn (v string) !string {", v_code)
+        self.assertIn("if '@' !in v {", v_code)
+        self.assertIn("return error('Invalid email')", v_code)
 
         # Check computed_field (as a method)
         self.assertIn("fn (self User) display_name() string {", v_code)
@@ -72,4 +74,7 @@ class MyModel(BaseModel):
 """
         v_code = self.translate(code)
         self.assertIn("fn (mut m MyModel) validate() ! {", v_code)
-        self.assertIn("m.check_sum()", v_code)
+        self.assertIn("m = fn (mut self MyModel) !MyModel {", v_code)
+        self.assertIn("if self.x + self.y > 100 {", v_code)
+        self.assertIn("return error('sum too large')", v_code)
+        self.assertIn("}(mut m) !", v_code)

--- a/py2v_transpiler/tests/translator/test_pydantic_validators.py
+++ b/py2v_transpiler/tests/translator/test_pydantic_validators.py
@@ -1,0 +1,103 @@
+import unittest
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+class TestPydanticValidators(unittest.TestCase):
+    def setUp(self):
+        self.parser = PyASTParser()
+        self.type_inference = TypeInference()
+
+    def translate(self, code: str) -> str:
+        tree = self.parser.parse(code)
+        self.type_inference.run_mypy(code)
+        visitor = VNodeVisitor(self.type_inference)
+        visitor.visit(tree)
+        return visitor.emitter.emit()
+
+    def test_field_validator(self):
+        code = """
+from pydantic import BaseModel, field_validator
+
+class User(BaseModel):
+    name: str
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if len(v) < 2:
+            raise ValueError('Name too short')
+        return v.title()
+"""
+        v_code = self.translate(code)
+        # Check if validate() calls the anonymous function correctly
+        self.assertIn("m.name = fn (v string) !string {", v_code)
+        self.assertIn("return error('Name too short')", v_code)
+        self.assertIn("}(m.name) !", v_code)
+        # Ensure it is not also visited as a normal method
+        self.assertNotIn("fn User_validate_name", v_code)
+
+    def test_model_validator(self):
+        code = """
+from pydantic import BaseModel, model_validator
+
+class User(BaseModel):
+    password: str
+    confirm_password: str
+
+    @model_validator(mode='after')
+    def check_passwords(self) -> 'User':
+        if self.password != self.confirm_password:
+            raise ValueError('Passwords do not match')
+        return self
+"""
+        v_code = self.translate(code)
+        self.assertIn("m = fn (mut self User) !User {", v_code)
+        self.assertIn("return error('Passwords do not match')", v_code)
+        self.assertIn("}(mut m) !", v_code)
+
+    def test_legacy_validator(self):
+        code = """
+from pydantic import BaseModel, validator
+
+class User(BaseModel):
+    name: str
+
+    @validator('name', pre=True)
+    def validate_name(cls, v: str) -> str:
+        if not v:
+            raise ValueError('Empty name')
+        return v
+"""
+        v_code = self.translate(code)
+        # validator(pre=True) -> mode='before'
+        # In validate_method, before-validators come before field constraints.
+        # We can't easily check order without more regex, but we check presence.
+        self.assertIn("m.name = fn (v string) !string {", v_code)
+        self.assertIn("return error('Empty name')", v_code)
+
+    def test_root_validator(self):
+        code = """
+from pydantic import BaseModel, root_validator
+
+class User(BaseModel):
+    a: int
+    b: int
+
+    @root_validator(pre=False)
+    def check_sum(cls, values: dict) -> dict:
+        if values.get('a', 0) + values.get('b', 0) > 10:
+            raise ValueError('Sum too large')
+        return values
+"""
+        v_code = self.translate(code)
+        # root_validator maps to model_validator in our processor
+        self.assertIn("m = fn (mut self User) !User {", v_code)
+        # Note: 'values' in root_validator(pre=False) is a dict, but our closure uses 'self' (the struct)
+        # This is an approximation as V doesn't use dicts for Pydantic models.
+        # However, the user-defined logic might need manual adjustment if they use .get() on a struct.
+        # But for now, we follow the closure pattern.
+        self.assertIn("return error('Sum too large')", v_code)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implemented transpilation for Pydantic @field_validator and @model_validator decorators (including legacy v1 @validator and @root_validator). Validation logic is now emitted as V closures within the struct's .validate() ! method, with Python raise statements correctly converted to V error returns. Existing tests were updated to reflect the new output format.

Fixes #284

---
*PR created automatically by Jules for task [9960584275143493531](https://jules.google.com/task/9960584275143493531) started by @yaskhan*