### PR TITLE
Fix mixed-type dictionary mapping and json.loads translation

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -577,7 +577,7 @@ class TranslatorBase(ast.NodeVisitor):
              if isinstance(node.value, str): return "string"
              if isinstance(node.value, bytes): return "[]u8"
              if isinstance(node.value, complex): return "PyComplex"
-             if node.value is None: return "int"
+             if node.value is None: return "Any"
              return "int"
         elif isinstance(node, (ast.UnaryOp)):
             if isinstance(node.op, ast.Not):
@@ -638,6 +638,8 @@ class TranslatorBase(ast.NodeVisitor):
             v_type = "Any"
             if len(val_types) == 1:
                 v_type = list(val_types)[0]
+            elif len(val_types) > 1:
+                v_type = "Any"
 
             return f"map[{k_type}]{v_type}"
         elif isinstance(node, ast.Name):

--- a/py2v_transpiler/core/translator/literals.py
+++ b/py2v_transpiler/core/translator/literals.py
@@ -176,6 +176,9 @@ class LiteralsMixin(TranslatorBase):
                 val_str = self.visit(v)
                 pairs.append(f"{key_str}: {val_str}")
 
+        if "Any" in v_type:
+            return f"{v_type}{{{', '.join(pairs)}}}"
+
         return f"{{{', '.join(pairs)}}}"
 
     def visit_Set(self, node: ast.Set) -> str:

--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -371,8 +371,8 @@ class StdLibMapper:
 
     def _json_loads(self, args: List[str]) -> str:
         if len(args) >= 1:
-             # Default to map[string]string for generic JSON object
-             return f"json.decode(map[string]string, {args[0]}) or {{}}"
+             # Default to map[string]Any for generic JSON object
+             return f"json.decode(map[string]Any, {args[0]}) or {{ panic(err) }}"
         return "/* json.loads args error */"
 
     def _time_time(self, args: List[str]) -> str:

--- a/py2v_transpiler/tests/translator/test_none_initialization.py
+++ b/py2v_transpiler/tests/translator/test_none_initialization.py
@@ -15,8 +15,8 @@ def transpile(code: str) -> str:
 def test_none_initialization_untyped():
     code = "planner = None"
     v_code = transpile(code)
-    # the analyzer falls back to 'int' in _guess_type
-    assert "mut planner := (none as ?int)" in v_code
+    # the analyzer falls back to 'Any' (formerly 'int') in _guess_type
+    assert "mut planner := (none as ?Any)" in v_code
 
 def test_none_initialization_typed():
     code = "planner: Planner = None"


### PR DESCRIPTION
This change addresses compilation errors in transpiled V code when using mixed-type Python dictionaries or `json.loads`.

1. **Mixed-type Dictionary Support**:
   - `TranslatorBase._guess_type` now detects when a dictionary literal has values of multiple types and infers its type as `map[K]Any`.
   - `LiteralsMixin.visit_Dict` now prepends the explicit V type (e.g., `map[string]Any{...}`) to such literals. This allows the V compiler to correctly treat the members as the `Any` sum type.

2. **JSON Loading Improvements**:
   - The `json.loads` mapper now defaults to `map[string]Any` for decoding.
   - It also generates `or { panic(err) }` instead of `or {}`, satisfying modern V requirements for handling Result types in assignment expressions.

3. **Type Inference Fixes**:
   - `None` constants are now inferred as `Any` instead of `int` when used in untyped contexts, leading to more correct `(none as ?Any)` initializations.

Verified with a reproduction script and by running the full test suite (623 tests passed).

Fixes #322

---
*PR created automatically by Jules for task [3498676923089636638](https://jules.google.com/task/3498676923089636638) started by @yaskhan*