### PR TITLE
Fix math.log Argument Mismatch and Ensure f64 Casting

### DIFF
--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -5,28 +5,28 @@ class StdLibMapper:
         # Maps Python module -> { Python function -> V function or transformation }
         self.mappings: Dict[str, Dict[str, Union[str, Callable[[List[str]], str]]]] = {
             "math": {
-                "sqrt": "math.sqrt",
-                "sin": "math.sin",
-                "cos": "math.cos",
-                "tan": "math.tan",
-                "asin": "math.asin",
-                "acos": "math.acos",
-                "atan": "math.atan",
-                "atan2": "math.atan2",
-                "sinh": "math.sinh",
-                "cosh": "math.cosh",
-                "tanh": "math.tanh",
-                "exp": "math.exp",
-                "log": "math.log",
-                "log10": "math.log10",
-                "pow": "math.pow",
-                "ceil": "math.ceil",
-                "floor": "math.floor",
-                "fabs": "math.abs",
+                "sqrt": self._math_unary_f64("math.sqrt"),
+                "sin": self._math_unary_f64("math.sin"),
+                "cos": self._math_unary_f64("math.cos"),
+                "tan": self._math_unary_f64("math.tan"),
+                "asin": self._math_unary_f64("math.asin"),
+                "acos": self._math_unary_f64("math.acos"),
+                "atan": self._math_unary_f64("math.atan"),
+                "atan2": self._math_atan2,
+                "sinh": self._math_unary_f64("math.sinh"),
+                "cosh": self._math_unary_f64("math.cosh"),
+                "tanh": self._math_unary_f64("math.tanh"),
+                "exp": self._math_unary_f64("math.exp"),
+                "log": self._math_log,
+                "log10": self._math_unary_f64("math.log10"),
+                "pow": self._math_pow,
+                "ceil": self._math_unary_f64("math.ceil"),
+                "floor": self._math_unary_f64("math.floor"),
+                "fabs": self._math_unary_f64("math.abs"),
                 "pi": "math.pi",
                 "e": "math.e",
-                "degrees": "math.degrees",
-                "radians": "math.radians",
+                "degrees": self._math_unary_f64("math.degrees"),
+                "radians": self._math_unary_f64("math.radians"),
             },
             "random": {
                 "randint": self._random_randint,
@@ -355,6 +355,30 @@ class StdLibMapper:
         return self.v_imports.get(module)
 
     # specialized handlers
+
+    def _math_unary_f64(self, v_func: str) -> Callable[[List[str]], str]:
+        def handler(args: List[str]) -> str:
+            if len(args) == 1:
+                return f"{v_func}(f64({args[0]}))"
+            return f"/* {v_func} args error */"
+        return handler
+
+    def _math_log(self, args: List[str]) -> str:
+        if len(args) == 1:
+            return f"math.log(f64({args[0]}))"
+        elif len(args) == 2:
+            return f"math.log_n(f64({args[0]}), f64({args[1]}))"
+        return "/* math.log args error */"
+
+    def _math_pow(self, args: List[str]) -> str:
+        if len(args) == 2:
+            return f"math.pow(f64({args[0]}), f64({args[1]}))"
+        return "/* math.pow args error */"
+
+    def _math_atan2(self, args: List[str]) -> str:
+        if len(args) == 2:
+            return f"math.atan2(f64({args[0]}), f64({args[1]}))"
+        return "/* math.atan2 args error */"
 
     def _io_stringio(self, args: List[str]) -> str:
         if len(args) == 0:

--- a/py2v_transpiler/tests/translator/test_math_mapper.py
+++ b/py2v_transpiler/tests/translator/test_math_mapper.py
@@ -1,0 +1,25 @@
+import math
+from py2v_transpiler.stdlib_map.mapper import StdLibMapper
+
+def test_mapper_math_log():
+    mapper = StdLibMapper()
+
+    # math.log(x) -> math.log(f64(x))
+    assert mapper.get_mapping("math", "log", ["10"]) == "math.log(f64(10))"
+
+    # math.log(x, base) -> math.log_n(f64(x), f64(base))
+    assert mapper.get_mapping("math", "log", ["10", "2"]) == "math.log_n(f64(10), f64(2))"
+
+    # math.log10(x) -> math.log10(f64(x))
+    assert mapper.get_mapping("math", "log10", ["100"]) == "math.log10(f64(100))"
+
+def test_mapper_math_unary():
+    mapper = StdLibMapper()
+    assert mapper.get_mapping("math", "sin", ["90"]) == "math.sin(f64(90))"
+    assert mapper.get_mapping("math", "sqrt", ["16"]) == "math.sqrt(f64(16))"
+    assert mapper.get_mapping("math", "ceil", ["4.2"]) == "math.ceil(f64(4.2))"
+
+def test_mapper_math_binary():
+    mapper = StdLibMapper()
+    assert mapper.get_mapping("math", "pow", ["2", "3"]) == "math.pow(f64(2), f64(3))"
+    assert mapper.get_mapping("math", "atan2", ["1", "1"]) == "math.atan2(f64(1), f64(1))"


### PR DESCRIPTION
This PR fixes an issue where Python's `math.log(x, base)` was incorrectly translated to a 2-argument call to V's `math.log`, which only accepts one argument. It also addresses the strict typing of V's `math` module by ensuring all arguments are explicitly cast to `f64` during transpilation.

Key changes:
- `math.log(x)` translates to `math.log(f64(x))`
- `math.log(x, base)` translates to `math.log_n(f64(x), f64(base))`
- Other math functions like `math.sin(x)`, `math.sqrt(x)`, and `math.pow(x, y)` now correctly include `f64()` casts.
- Added a new test file `py2v_transpiler/tests/translator/test_math_mapper.py` to verify these mappings.

Fixes #325

---
*PR created automatically by Jules for task [18037585677117662772](https://jules.google.com/task/18037585677117662772) started by @yaskhan*