### PR TITLE
Fix missing Result/Error handling for I/O operations

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -599,6 +599,7 @@ class TranslatorBase(ast.NodeVisitor):
                 if fid == "bool": return "bool"
                 if fid == "len": return "int"
                 if fid == "input": return "string"
+                if fid == "open": return "os.File"
                 if fid in ("bytearray", "memoryview", "bytes"): return "[]u8"
                 if fid in ("isinstance", "hasattr", "getattr", "setattr"): return "bool"
                 if fid in ("bytes", "bytearray", "memoryview"): return "[]u8"
@@ -610,6 +611,8 @@ class TranslatorBase(ast.NodeVisitor):
                     return "map[Any]bool"
             elif isinstance(node.func, ast.Attribute) and node.func.attr == "bytes":
                 return "[]u8"
+            elif isinstance(node.func, ast.Attribute) and node.func.attr == "open" and isinstance(node.func.value, ast.Name) and node.func.value.id == "os":
+                return "os.File"
         elif isinstance(node, (ast.List, ast.Tuple)):
             if not node.elts:
                 return "[]Any"

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -697,6 +697,23 @@ class CallsMixin(TranslatorBase):
             elif func_node.attr == "clear":
                 obj = self.visit(func_node.value)
                 return f"/* {obj}.clear() */ {obj} = {{}}"
+            elif func_node.attr in ("read", "write", "close"):
+                obj_type = self._guess_type(func_node.value)
+                if obj_type == "os.File" or obj_type == "Any":
+                    obj = self.visit(func_node.value)
+                    if func_node.attr == "read":
+                        return f"{obj}.read() or {{ panic(err) }}"
+                    elif func_node.attr == "write":
+                        if len(args) >= 1:
+                            arg_type = self._guess_type(node.args[0])
+                            write_arg = args[0]
+                            if arg_type == "string":
+                                write_arg = f"{write_arg}.bytes()"
+                            return f"{obj}.write({write_arg}) or {{ panic(err) }}"
+                        return f"{obj}.write() or {{ panic(err) }}"
+                    else:
+                        # close
+                        return f"{obj}.close() or {{ panic(err) }}"
 
         # Handle list.sort(reverse=True)
         if isinstance(func_node, ast.Attribute) and func_node.attr == "sort":

--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -64,11 +64,11 @@ class StdLibMapper:
                 "getcwd": "os.getwd",
                 "system": "os.system",
                 "getenv": "os.getenv",
-                "mkdir": "os.mkdir",
-                "makedirs": "os.mkdir_all",
-                "remove": "os.rm",
-                "rmdir": "os.rmdir",
-                "listdir": "os.ls",
+                "mkdir": self._os_mkdir,
+                "makedirs": self._os_mkdir_all,
+                "remove": self._os_remove,
+                "rmdir": self._os_rmdir,
+                "listdir": self._os_ls,
                 "path.join": "os.join_path",
                 "path.exists": "os.exists",
                 "path.isfile": "os.is_file",
@@ -622,3 +622,28 @@ class StdLibMapper:
 
     def _platform_python_implementation(self, args: List[str]) -> str:
         return "'V'"
+
+    def _os_remove(self, args: List[str]) -> str:
+        if len(args) >= 1:
+            return f"os.rm({args[0]}) or {{ panic(err) }}"
+        return "/* os.remove args error */"
+
+    def _os_mkdir(self, args: List[str]) -> str:
+        if len(args) >= 1:
+            return f"os.mkdir({args[0]}) or {{ panic(err) }}"
+        return "/* os.mkdir args error */"
+
+    def _os_mkdir_all(self, args: List[str]) -> str:
+        if len(args) >= 1:
+            return f"os.mkdir_all({args[0]}) or {{ panic(err) }}"
+        return "/* os.makedirs args error */"
+
+    def _os_rmdir(self, args: List[str]) -> str:
+        if len(args) >= 1:
+            return f"os.rmdir({args[0]}) or {{ panic(err) }}"
+        return "/* os.rmdir args error */"
+
+    def _os_ls(self, args: List[str]) -> str:
+        if len(args) >= 1:
+            return f"os.ls({args[0]}) or {{ panic(err) }}"
+        return "/* os.listdir args error */"


### PR DESCRIPTION
This change ensures that V's Result-returning I/O operations are correctly handled by the transpiler. It addresses the missing error handling for `os` module functions and `os.File` methods. By using `or { panic(err) }`, it maintains compatibility with standard Python-translated V functions that do not return Result types. Additionally, it improves type inference for file objects and ensures correct argument types for the `write` method.

Fixes #329

---
*PR created automatically by Jules for task [16401555425680022856](https://jules.google.com/task/16401555425680022856) started by @yaskhan*