### PR TITLE
Fix dict.get() and os.environ.get() visibility in V

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -322,6 +322,15 @@ class CallsMixin(TranslatorBase):
         elif original_id and f"py_{original_id}" == func_name_str and original_id in ("map", "filter"):
              func_name_str = original_id
 
+        # Handle dict.get(key, default) -> dict[key] or { default }
+        if isinstance(func_node, ast.Attribute) and func_node.attr == "get" and (len(args) == 1 or len(args) == 2):
+            obj_type = self._guess_type(func_node.value)
+            if obj_type.startswith("map[") or obj_type == "Any":
+                obj = self.visit(func_node.value)
+                key = args[0]
+                default = args[1] if len(args) == 2 else "none"
+                return f"{obj}[{key}] or {{ {default} }}"
+
         # Extract mypy plugin signature if available for this call
         loc_key = f"{getattr(node, 'lineno', 0)}:{getattr(node, 'col_offset', 0)}"
         call_sig = None


### PR DESCRIPTION
The transpiler now correctly handles `.get()` calls on dictionary-like objects and `os.environ`. In V, the `.get()` method on maps is private, so it must be accessed using the `obj[key] or { default }` syntax. The fix was implemented in `CallsMixin.visit_Call` to intercept `.get()` calls on objects inferred as maps or `Any`. All 630 existing tests passed, and the fix was verified with a reproduction script.

Fixes #326

---
*PR created automatically by Jules for task [16761186462990015854](https://jules.google.com/task/16761186462990015854) started by @yaskhan*