### PR TITLE
Fix os.path.exists Boolean Return Type Mismatch

### DIFF
--- a/py2v_transpiler/core/translator/base.py
+++ b/py2v_transpiler/core/translator/base.py
@@ -622,6 +622,24 @@ class TranslatorBase(ast.NodeVisitor):
                 return "[]u8"
             elif isinstance(node.func, ast.Attribute) and node.func.attr == "open" and isinstance(node.func.value, ast.Name) and node.func.value.id == "os":
                 return "os.File"
+            elif isinstance(node.func, ast.Attribute) and node.func.attr in ("exists", "isfile", "isdir"):
+                # Handle os.path.exists or from os import path; path.exists
+                curr = node.func.value
+                parts = [node.func.attr]
+                while isinstance(curr, ast.Attribute):
+                    parts.append(curr.attr)
+                    curr = curr.value
+                if isinstance(curr, ast.Name):
+                    parts.append(curr.id)
+
+                parts.reverse()
+                full_name = ".".join(parts)
+                if full_name in ("os.path.exists", "os.path.isfile", "os.path.isdir"):
+                    return "bool"
+
+                # Check for path.exists if 'from os import path' was used
+                if len(parts) >= 2 and parts[-2] == "path" and parts[-1] in ("exists", "isfile", "isdir"):
+                    return "bool"
         elif isinstance(node, (ast.List, ast.Tuple)):
             if not node.elts:
                 return "[]Any"


### PR DESCRIPTION
The transpiler was incorrectly assuming that `os.path.exists` (which maps to `os.exists` in V) returned an integer, leading it to generate code like `if os.exists(filename) != 0 { ... }`. Since V's `os.exists` returns a boolean, this caused a compilation error.

This change updates the type inference logic in `TranslatorBase._guess_type` to recognize these common path check functions as boolean-returning, ensuring they are used directly in conditionals.

Fixed functions:
- `os.path.exists`
- `os.path.isfile`
- `os.path.isdir`
(Handles both fully-qualified and `from os import path` styles)

Fixes #328

---
*PR created automatically by Jules for task [4679907444251625306](https://jules.google.com/task/4679907444251625306) started by @yaskhan*