### PR TITLE
Map Python string methods `splitlines` and `join` to V equivalents

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -878,15 +878,16 @@ class CallsMixin(TranslatorBase):
                 return f"os.input({args[0]})"
             return "os.input('')"
 
-        # String predicates
-        # isdigit, isalpha, isalnum, isspace, islower, isupper, istitle, startswith, endswith
+        # String predicates and methods
+        # isdigit, isalpha, isalnum, isspace, islower, isupper, istitle, startswith, endswith, splitlines, join
         # These are usually called as methods on strings: "s.isdigit()"
         # But visit_Call handles method calls too.
         # Check if the function name matches a known string predicate.
         # And implicitly assume the receiver is a string (or we rely on V compiler error if not).
         # We handle them if func_node is Attribute.
         elif isinstance(func_node, ast.Attribute) and func_node.attr in (
-            "isdigit", "isalpha", "isalnum", "isspace", "islower", "isupper", "istitle", "startswith", "endswith"
+            "isdigit", "isalpha", "isalnum", "isspace", "islower", "isupper", "istitle", "startswith", "endswith",
+            "splitlines", "join"
         ) and not module_name:
              attr = func_node.attr
              obj = self.visit(func_node.value)
@@ -904,6 +905,11 @@ class CallsMixin(TranslatorBase):
                  return f"{obj}.is_upper()"
              elif attr == "istitle":
                  return f"{obj}.is_title()"
+             elif attr == "splitlines":
+                 return f"{obj}.split_into_lines()"
+             elif attr == "join":
+                 if len(args) == 1:
+                     return f"{args[0]}.join({obj})"
              elif attr in ("startswith", "endswith"):
                  v_method = "starts_with" if attr == "startswith" else "ends_with"
                  if len(node.args) == 1 and isinstance(node.args[0], ast.Tuple):


### PR DESCRIPTION
This PR fixes a transpilation mismatch where Python's `splitlines()` and `join()` string methods were being emitted as-is, causing compilation errors in V.

- Python's `.splitlines()` is now correctly transpiled to V's `.split_into_lines()`.
- Python's `separator.join(iterable)` is now correctly transformed into V's idiomatic `iterable.join(separator)`.

These changes were implemented in `py2v_transpiler/core/translator/expressions_split/calls.py` within the `visit_Call` method. Verification was performed using a reproduction script and by running the full test suite (646 tests passed).

Fixes #327

---
*PR created automatically by Jules for task [6008443627682619221](https://jules.google.com/task/6008443627682619221) started by @yaskhan*