### PR TITLE
Fix Missing Module Imports in Generated V Code

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/attributes.py
+++ b/py2v_transpiler/core/translator/expressions_split/attributes.py
@@ -9,6 +9,11 @@ class AttributesMixin(TranslatorBase):
              const_name = node.attr
              mapped = self.mapper.get_constant_mapping(module_name, const_name)
              if mapped:
+                 # Add automatic V imports for the module
+                 v_imports = self.mapper.get_imports(module_name)
+                 if v_imports:
+                     for imp in v_imports:
+                         self.emitter.add_import(imp)
                  return mapped
 
         if node.attr == "__class__":

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -170,6 +170,11 @@ class CallsMixin(TranslatorBase):
 
             mapped = self.mapper.get_mapping(module_name, func_name, args)
             if mapped:
+                # Add automatic V imports for the module
+                v_imports = self.mapper.get_imports(module_name)
+                if v_imports:
+                    for imp in v_imports:
+                        self.emitter.add_import(imp)
                 return mapped
 
         # Try finding os.path.X by concatenating if attribute access

--- a/py2v_transpiler/core/translator/imports.py
+++ b/py2v_transpiler/core/translator/imports.py
@@ -27,6 +27,7 @@ class ImportsMixin(TranslatorBase):
             # Add V imports via mapper
             v_imports = self.mapper.get_imports(module_name)
             if v_imports is not None:
+                # If mapped to [], skip import (ignore module)
                 for imp in v_imports:
                     self.emitter.add_import(imp)
             else:
@@ -55,6 +56,7 @@ class ImportsMixin(TranslatorBase):
             # Add V imports
             v_imports = self.mapper.get_imports(module_name)
             if v_imports is not None:
+                # If mapped to [], skip import
                 for imp in v_imports:
                     self.emitter.add_import(imp)
             # Else? For ImportFrom, we don't necessarily import the module if not mapped,

--- a/py2v_transpiler/stdlib_map/mapper.py
+++ b/py2v_transpiler/stdlib_map/mapper.py
@@ -293,6 +293,10 @@ class StdLibMapper:
             "zlib": ["compress.zlib"],
             "gzip": ["compress.gzip"],
             "copy": [],
+            "collections": [],
+            "itertools": [],
+            "functools": [],
+            "operator": [],
             "struct": ["encoding.binary"],
             "array": [],
             "fractions": ["math.fractions"],
@@ -301,6 +305,15 @@ class StdLibMapper:
             "pickle": ["json"],
             "contextlib": [],
             "typing": [],
+            "ast": [],
+            "pytest": [],
+            "pytest_mock": [],
+            "mock": [],
+            "abc": [],
+            "unittest": [],
+            "types": [],
+            "enum": [],
+            "string": ["strings"],
         }
 
     def get_mapping(self, module: str, func: str, args: List[str]) -> Optional[str]:

--- a/py2v_transpiler/tests/translator/test_strings.v
+++ b/py2v_transpiler/tests/translator/test_strings.v
@@ -1,0 +1,32 @@
+module main
+
+pub fn test_translator_f_string_simple() {
+    mut parser := py2v_transpiler.core.parser.PyASTParser()
+    mut analyzer := py2v_transpiler.core.analyzer.TypeInference()
+    mut translator := py2v_transpiler.core.translator.VNodeVisitor(analyzer)
+    mut code := 'f\'value: {x}\''
+    mut tree := parser.parse(code)
+    analyzer.analyze(tree)
+    mut result := translator.visit_Module(tree)
+    assert '\'value: ${x}\'' in result
+}
+pub fn test_translator_f_string_expression() {
+    mut parser := py2v_transpiler.core.parser.PyASTParser()
+    mut analyzer := py2v_transpiler.core.analyzer.TypeInference()
+    mut translator := py2v_transpiler.core.translator.VNodeVisitor(analyzer)
+    mut code := 'f\'{x + 1}\''
+    mut tree := parser.parse(code)
+    analyzer.analyze(tree)
+    mut result := translator.visit_Module(tree)
+    assert '\'${x + 1}\'' in result
+}
+pub fn test_translator_f_string_mixed() {
+    mut parser := py2v_transpiler.core.parser.PyASTParser()
+    mut analyzer := py2v_transpiler.core.analyzer.TypeInference()
+    mut translator := py2v_transpiler.core.translator.VNodeVisitor(analyzer)
+    mut code := 'f\'a={a}, b={b}\''
+    mut tree := parser.parse(code)
+    analyzer.analyze(tree)
+    mut result := translator.visit_Module(tree)
+    assert '\'a=${a}, b=${b}\'' in result
+}

--- a/py2v_transpiler/tests/translator/test_strings_helpers.v
+++ b/py2v_transpiler/tests/translator/test_strings_helpers.v
@@ -1,0 +1,65 @@
+module main
+
+pub type Any = bool | int | i64 | f64 | string | []u8 | none
+
+struct PyGeneratorInput {
+    val Any
+    is_exc bool
+    exc_msg string
+}
+struct PyGenerator[T] {
+mut:
+    out chan T
+    in_ chan PyGeneratorInput
+    open bool = true
+}
+
+fn (mut g PyGenerator[T]) next() ?T {
+    if !g.open { return none }
+    g.in_ <- PyGeneratorInput{val: 0} // Send dummy value
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) send(val Any) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{val: val}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) throw(msg string) ?T {
+    if !g.open { panic('StopIteration') }
+    g.in_ <- PyGeneratorInput{is_exc: true, exc_msg: msg}
+    res := <-g.out
+    if res == none { g.open = false }
+    return res
+}
+fn (mut g PyGenerator[T]) close() {
+    g.open = false
+    g.in_.close()
+    // g.out will be closed by the generator function loop when it detects in_ closed or panic
+}
+fn py_yield[T](ch_out chan T, ch_in chan PyGeneratorInput, val T) Any {
+    ch_out <- val
+    inp := <-ch_in
+    if inp.is_exc {
+        panic(inp.exc_msg)
+    }
+    return inp.val
+}
+fn py_bytes_format(fmt []u8, args Any) []u8 {
+    // Simplistic implementation for b'%s' % b'val'
+    // Converts bytes to string, formats, and converts back.
+    // This is not efficient or correct for non-ASCII bytes but works for simple cases.
+    fmt_str := fmt.bytestr()
+    // TODO: handle args properly. V's string interpolation/formatting expects distinct args.
+    // If args is []u8, treat as string.
+    arg_str := if args is []u8 { args.bytestr() } else { '${args}' }
+
+    // Manual substitution of %s
+    // V does not have sprintf for runtime strings easily available in core without C interop.
+    // Simple replace for %s
+    res := fmt_str.replace('%s', arg_str)
+    return res.bytes()
+}


### PR DESCRIPTION
Implemented automatic V import detection and refined module mapping to ensure generated V code correctly imports required modules and ignores unnecessary Python-only modules. Added automatic import triggers in `visit_Call` and `visit_Attribute` for mapped symbols. Suppressed common Python test and metadata modules (ast, pytest, etc.). Verified fixes against affected test cases.

Fixes #350

---
*PR created automatically by Jules for task [16042543964006709657](https://jules.google.com/task/16042543964006709657) started by @yaskhan*