### PR TITLE
Fix Invalid Type Syntax in Generated V Code

### DIFF
--- a/py2v_transpiler/core/translator/classes.py
+++ b/py2v_transpiler/core/translator/classes.py
@@ -1,6 +1,5 @@
 import ast
 from typing import List, Optional, Set
-from py2v_transpiler.models.v_types import map_python_type_to_v
 from .base import TranslatorBase
 
 

--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -2,7 +2,6 @@ import ast
 import re
 from typing import List, Any
 from ..base import TranslatorBase
-from py2v_transpiler.models.v_types import map_python_type_to_v
 
 class CallsMixin(TranslatorBase):
     def visit_Call(self, node: ast.Call) -> str:
@@ -160,8 +159,7 @@ class CallsMixin(TranslatorBase):
                     if len(args) == 2:
                         try:
                             type_str = ast.unparse(node.args[0])
-                            from py2v_transpiler.models.v_types import map_python_type_to_v
-                            v_type = map_python_type_to_v(type_str)
+                            v_type = self._map_type(type_str)
                         except Exception:
                             v_type = str(self.visit(node.args[0]))
                         val = args[1]
@@ -398,7 +396,7 @@ class CallsMixin(TranslatorBase):
                         else:
                             norm_typ = "int"
                     try:
-                        v_type = map_python_type_to_v(norm_typ)
+                        v_type = self._map_type(norm_typ)
                     except Exception:
                         v_type = "Any"
                     # Ensure we map mypy's builtins correctly, even if mapping failed
@@ -499,12 +497,10 @@ class CallsMixin(TranslatorBase):
                 expr_type = self._guess_type(expr_node)
                 try:
                     type_str = ast.unparse(type_node)
-                    from py2v_transpiler.models.v_types import map_python_type_to_v as local_map_fn
-                    expected_type = local_map_fn(type_str)
+                    expected_type = self._map_type(type_str)
                 except Exception:
                     type_str = str(self.visit(type_node))
-                    from py2v_transpiler.models.v_types import map_python_type_to_v as local_map_fn
-                    expected_type = local_map_fn(type_str)
+                    expected_type = self._map_type(type_str)
 
                 if expr_type == expected_type:
                     return f"// assert_type({args[0]}, {expected_type}) passed statically"
@@ -520,7 +516,31 @@ class CallsMixin(TranslatorBase):
             return "// assert_never requires 1 argument"
 
         # Handle primitive type "casting" or conversions (priority over class instantiation)
-        if func_name_str == "int" or (original_id == "int" and func_name_str == "py_int"):
+        if func_name_str == "dict" or (original_id == "dict" and func_name_str == "py_dict"):
+            v_type = getattr(self, "current_assignment_type", "map[string]Any")
+            if not v_type.startswith("map["): v_type = "map[string]Any"
+            if len(args) == 0:
+                return f"{v_type}{{}}"
+            return f"{v_type}({', '.join(args)})"
+        elif func_name_str == "list" or (original_id == "list" and func_name_str == "py_list"):
+            v_type = getattr(self, "current_assignment_type", "[]Any")
+            if not v_type.startswith("[]"): v_type = "[]Any"
+            if len(args) == 0:
+                return f"{v_type}{{}}"
+            return f"{v_type}({', '.join(args)})"
+        elif func_name_str == "tuple" or (original_id == "tuple" and func_name_str == "py_tuple"):
+            v_type = getattr(self, "current_assignment_type", "[]Any")
+            if not v_type.startswith("["): v_type = "[]Any"
+            if len(args) == 0:
+                return f"{v_type}{{}}"
+            return f"{v_type}({', '.join(args)})"
+        elif func_name_str == "set" or (original_id == "set" and func_name_str == "py_set"):
+            v_type = getattr(self, "current_assignment_type", "map[Any]bool")
+            if not v_type.startswith("map["): v_type = "map[Any]bool"
+            if len(args) == 0:
+                return f"{v_type}{{}}"
+            return f"{v_type}({', '.join(args)})"
+        elif func_name_str == "int" or (original_id == "int" and func_name_str == "py_int"):
             if len(args) == 0:
                 return "0"
             elif len(args) == 1:
@@ -865,13 +885,11 @@ class CallsMixin(TranslatorBase):
                     type_str = ast.unparse(type_node)
                     # For assert_type error messages, it might be better to compare original mapped type names
                     # but map_python_type_to_v converts float to f64, so test expects f64.
-                    from py2v_transpiler.models.v_types import map_python_type_to_v as local_map_fn
-                    expected_type = local_map_fn(type_str)
+                    expected_type = self._map_type(type_str)
                 except Exception:
                     # Fallback if unparse fails
                     type_str = str(self.visit(type_node))
-                    from py2v_transpiler.models.v_types import map_python_type_to_v as local_map_fn
-                    expected_type = local_map_fn(type_str)
+                    expected_type = self._map_type(type_str)
 
                 if expr_type == expected_type:
                     return f"// assert_type({args[0]}, {expected_type}) passed statically"

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -1,6 +1,5 @@
 import ast
 from typing import Any, List, Optional, Dict
-from py2v_transpiler.models.v_types import map_python_type_to_v
 from .base import TranslatorBase
 
 
@@ -141,7 +140,7 @@ class FunctionsMixin(TranslatorBase):
                         if decorator.args:
                             try:
                                 type_str = ast.unparse(decorator.args[0])
-                                register_type = map_python_type_to_v(type_str)
+                                register_type = self._map_type(type_str)
                             except:
                                 pass
 
@@ -467,6 +466,7 @@ class FunctionsMixin(TranslatorBase):
 
         args_str = ", ".join(args_str_list)
 
+        # Handle return types for sum types
         ret_type = "void"
         if not is_generator and node.returns:
             try:
@@ -1075,7 +1075,7 @@ class FunctionsMixin(TranslatorBase):
         capture_str = f"[{', '.join(captures)}] " if captures else ""
 
         body = self.visit(node.body)
-        body_type = self._guess_type(node.body)
+        body_type = self._map_type(self._guess_type(node.body))
 
         return f"fn {capture_str}({args_str}) {body_type} {{ return {body} }}"
 

--- a/py2v_transpiler/core/translator/literals.py
+++ b/py2v_transpiler/core/translator/literals.py
@@ -172,6 +172,8 @@ class LiteralsMixin(TranslatorBase):
             # Empty dict
             v_type = getattr(self, "current_assignment_type", "map[string]Any")
             if not v_type.startswith("map["):
+                # If current_assignment_type is e.g. a struct or union,
+                # we should fallback to map[string]Any only if it's truly a dict literal.
                 v_type = "map[string]Any"
             return f"{v_type}{{}}"
 
@@ -180,10 +182,15 @@ class LiteralsMixin(TranslatorBase):
             if k:
                 key_str = self.visit(k)
                 val_str = self.visit(v)
+                if "Any" in v_type and not v_type.startswith("SumType"):
+                     val_str = f"({val_str} as Any)"
                 pairs.append(f"{key_str}: {val_str}")
 
-        if "Any" in v_type:
-            return f"{v_type}{{{', '.join(pairs)}}}"
+        # In modern V, map literals with elements should NOT have the type prefix
+        # unless it is ambiguous, but usually {key: val} is enough if context type is known.
+        # However, map[string]Any requires explicit casts for values.
+        if "Any" in v_type and not v_type.startswith("SumType"):
+             return f"{v_type}{{{', '.join(pairs)}}}"
 
         return f"{{{', '.join(pairs)}}}"
 
@@ -216,7 +223,7 @@ class LiteralsMixin(TranslatorBase):
             elements.append(f"{val}: true")
 
         v_type = self._guess_type(node)
-        if "Any" in v_type:
+        if "Any" in v_type and not v_type.startswith("SumType"):
             return f"{v_type}{{{', '.join(elements)}}}"
 
         return f"{{{', '.join(elements)}}}"
@@ -243,6 +250,12 @@ class LiteralsMixin(TranslatorBase):
             return f"py_list_concat({', '.join(chunks)})"
 
         elements = [str(self.visit(elt)) for elt in node.elts]
+
+        # Use fixed-size array literal if type is known to be fixed-size array
+        v_type = getattr(self, "current_assignment_type", "")
+        if v_type.startswith("[") and "]" in v_type and not v_type.startswith("[]"):
+             return f"{v_type}{{{', '.join(elements)}}}"
+
         return f"[{', '.join(elements)}]"
 
     def visit_JoinedStr(self, node: ast.JoinedStr) -> str:

--- a/py2v_transpiler/core/translator/variables_split/annotations.py
+++ b/py2v_transpiler/core/translator/variables_split/annotations.py
@@ -1,7 +1,6 @@
 import ast
 from typing import Any
 from ..base import TranslatorBase
-from py2v_transpiler.models.v_types import map_python_type_to_v
 
 
 class AnnotationsMixin(TranslatorBase):
@@ -91,6 +90,11 @@ class AnnotationsMixin(TranslatorBase):
                 for elt in value_node.elts:
                     val = self.visit(elt)
                     self.output.append(f"{self._indent()}{target} << {val}")
+            elif v_type.startswith("[") and "]" in v_type and not v_type.startswith("[]") and isinstance(node.value, (ast.List, ast.Tuple)):
+                self.current_assignment_type = v_type
+                rhs = self.visit(node.value)
+                del self.current_assignment_type
+                self.output.append(f"{self._indent()}mut {target} := {rhs}")
             elif hasattr(self, 'dataclasses') and v_type in self.dataclasses and isinstance(node.value, ast.Dict):
                 # TypedDict assignment
                 pairs = []

--- a/py2v_transpiler/models/v_types.py
+++ b/py2v_transpiler/models/v_types.py
@@ -154,6 +154,8 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
         elif value_id in ('Dict', 'dict', 'Mapping', 'MutableMapping'):
             if len(mapped_args) >= 2:
                 return f"map[{mapped_args[0]}]{mapped_args[1]}"
+            elif len(mapped_args) == 1:
+                 return f"map[{mapped_args[0]}]Any"
             return "map[string]int" # fallback
 
         elif value_id in ('IO', 'TextIO'):
@@ -161,18 +163,21 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
                 return "&strings.Builder"
             return "os.File"
 
-        elif value_id == 'Tuple':
+        elif value_id in ('Tuple', 'tuple'):
             # Tuple[int, ...] -> []int
             if len(mapped_args) == 2 and mapped_args[1] == '...':
                 return f"[]{mapped_args[0]}"
 
-            # Tuple[int, int] -> []int (if all same)
-            first = mapped_args[0] if mapped_args else 'Any'
-            if all(arg == first for arg in mapped_args):
-                return f"[]{first}"
+            if not mapped_args:
+                return "[]Any"
 
-            # Tuple[int, str] -> []Any
-            return "[]Any"
+            # Tuple[int, int] -> [2]int
+            first = mapped_args[0]
+            if all(arg == first for arg in mapped_args):
+                return f"[{len(mapped_args)}]{first}"
+
+            # Tuple[int, str] -> [2]Any
+            return f"[{len(mapped_args)}]Any"
 
         elif value_id == 'Optional':
             if mapped_args:
@@ -196,18 +201,19 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
             if len(non_none) == 1 and len(mapped_args) > 1:
                 return f"?{non_none[0]}"
 
-            if allow_union:
-                # Deduplicate while preserving order
-                unique_args = []
-                for arg in mapped_args:
-                    if arg not in unique_args:
-                        unique_args.append(arg)
+            # Deduplicate while preserving order
+            unique_args = []
+            for arg in mapped_args:
+                if arg not in unique_args:
+                    unique_args.append(arg)
 
-                union_str = " | ".join(unique_args)
-                if sum_type_registrar:
-                    if len(non_none) < len(mapped_args): # had none
-                        return f"?{sum_type_registrar(' | '.join(non_none))}"
-                    return sum_type_registrar(union_str)
+            union_str = " | ".join(unique_args)
+            if sum_type_registrar:
+                if len(non_none) < len(mapped_args): # had none
+                    return f"?{sum_type_registrar(' | '.join(non_none))}"
+                return sum_type_registrar(union_str)
+
+            if allow_union:
                 return union_str
             return "Any"
 
@@ -285,6 +291,18 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
         # Default generic mapping: Name[T]
         return f"{value_id}[{', '.join(mapped_args)}]"
 
+    elif isinstance(node, ast.Tuple):
+        # Handle tuple[int, str] in some contexts where it's not a Subscript but a Tuple node
+        # or when used as (int, str)
+        mapped_args = [_map_ast_type(elt, self_name, allow_union, generic_map, sum_type_registrar) for elt in node.elts]
+        if not mapped_args:
+            return "[]Any"
+
+        first = mapped_args[0]
+        if all(arg == first for arg in mapped_args):
+            return f"[{len(mapped_args)}]{first}"
+        return f"[{len(mapped_args)}]Any"
+
     elif isinstance(node, ast.BinOp):
         # A | B (Python 3.10+ Union)
         if isinstance(node.op, ast.BitOr):
@@ -296,10 +314,11 @@ def _map_ast_type(node: ast.AST, self_name: str = "Self", allow_union: bool = Tr
             if right_type == 'none':
                 return f"?{left_type}"
 
+            union_str = f"{left_type} | {right_type}"
+            if sum_type_registrar:
+                return sum_type_registrar(union_str)
+
             if allow_union:
-                union_str = f"{left_type} | {right_type}"
-                if sum_type_registrar:
-                    return sum_type_registrar(union_str)
                 return union_str
             return "Any"
 


### PR DESCRIPTION
Fixed transpiler issues where generated V code used deprecated inline sum types or invalid tuple/map syntax. Python tuples now map to V fixed-size arrays, unions map to named sum types, and map/list initialization is more idiomatic.

Fixes #351

---
*PR created automatically by Jules for task [12471937454583142461](https://jules.google.com/task/12471937454583142461) started by @yaskhan*