### PR TITLE
Fix invalid V type syntax and add regression tests

### DIFF
--- a/py2v_transpiler/tests/translator/test_type_syntax_fixes.py
+++ b/py2v_transpiler/tests/translator/test_type_syntax_fixes.py
@@ -1,0 +1,71 @@
+import pytest
+from .utils import TranspilerTest
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+import ast
+from typing import cast
+
+def translate(py_code: str) -> str:
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    tree = parser.parse(py_code)
+    analyzer.analyze(tree)
+    translator = VNodeVisitor(analyzer)
+    return translator.visit_Module(cast(ast.Module, tree))
+
+def test_fixed_size_tuple_mapping():
+    py_code = """
+def get_point(p: tuple[int, int]) -> tuple[int, int]:
+    return p
+"""
+    v_code = translate(py_code)
+    assert "fn get_point(p [2]int) [2]int {" in v_code
+    assert "return p" in v_code
+
+def test_heterogeneous_tuple_mapping():
+    py_code = """
+from typing import Tuple
+def process_data(data: Tuple[int, str]):
+    pass
+"""
+    v_code = translate(py_code)
+    assert "fn process_data(data [2]Any) {" in v_code
+
+def test_union_to_named_sum_type():
+    py_code = """
+def handle_input(x: int | str):
+    print(x)
+"""
+    v_code = translate(py_code)
+    # Check that it uses a named sum type
+    assert "type SumType_" in v_code
+    assert "fn handle_input(x SumType_" in v_code
+
+def test_optional_union_mapping():
+    py_code = """
+from typing import Optional, Union
+def find_item(id: int) -> Optional[Union[str, int]]:
+    return None
+"""
+    v_code = translate(py_code)
+    assert "type SumType_" in v_code
+    assert "fn find_item(id int) ?SumType_" in v_code
+
+def test_dict_initialization_mapping():
+    py_code = """
+def create_map():
+    d: dict[str, int] = dict()
+    return d
+"""
+    v_code = translate(py_code)
+    assert "d := map[string]int{}" in v_code
+
+def test_map_any_casting():
+    py_code = """
+def get_any_map() -> dict[str, int | str]:
+    return {"a": 1, "b": "hello"}
+"""
+    v_code = translate(py_code)
+    assert "(1 as Any)" in v_code
+    assert "('hello' as Any)" in v_code


### PR DESCRIPTION
This commit fixes several issues in the transpiler's type mapping:
- Replaced deprecated inline sum types with named sum types via a registration mechanism.
- Mapped Python tuples and `Tuple` to V fixed-size arrays (`[N]T` or `[N]Any`).
- Improved map/dict syntax and initialization, ensuring modern V compatibility and adding necessary casts for heterogeneous maps.
- Consolidated type mapping to always use `self._map_type` for correct sum type registration.
- Added 6 regression tests in `py2v_transpiler/tests/translator/test_type_syntax_fixes.py`.
- Removed all temporary reproduction scripts and artifacts.