### PR TITLE
Fix Generic Receiver Parameter Issue in @classmethod Generation

### DIFF
--- a/py2v_transpiler/core/translator/expressions_split/calls.py
+++ b/py2v_transpiler/core/translator/expressions_split/calls.py
@@ -704,14 +704,18 @@ class CallsMixin(TranslatorBase):
                     lookup_name = orig_id
                     break
 
+        # Strip generics for class lookup (e.g. UserDict[T] -> UserDict)
+        base_lookup_name = re.sub(r'\[.*\]', '', lookup_name)
+
         if call_sig and "is_class" in call_sig:
             is_class = call_sig["is_class"]
             has_factory = call_sig.get("has_init", False) or call_sig.get("has_new", False)
-        elif hasattr(self, 'defined_classes') and lookup_name in self.defined_classes:
+        elif hasattr(self, 'defined_classes') and base_lookup_name in self.defined_classes:
             is_class = True
-            class_info = self.defined_classes[lookup_name]
+            class_info = self.defined_classes[base_lookup_name]
             has_factory = class_info.get("has_init", False) or class_info.get("has_new", False)
-            func_name_str = lookup_name # Use non-prefixed name for call if it is a class
+            if lookup_name in self.defined_classes:
+                func_name_str = lookup_name # Use non-prefixed name for call if it is a class
 
         if is_class:
             if has_factory:

--- a/py2v_transpiler/core/translator/functions.py
+++ b/py2v_transpiler/core/translator/functions.py
@@ -68,7 +68,16 @@ class FunctionsMixin(TranslatorBase):
 
             # Handle self/cls
             is_method = self.current_class is not None
-            if is_method and args and (args[0].arg == "self" or (node.name == "__new__" and args[0].arg == "cls")):
+            is_cls_method = False
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Name) and decorator.id == "classmethod":
+                    is_cls_method = True
+                    break
+                if isinstance(decorator, ast.Attribute) and decorator.attr == "classmethod":
+                    is_cls_method = True
+                    break
+
+            if is_method and args and (args[0].arg == "self" or is_cls_method or (node.name == "__new__" and args[0].arg == "cls")):
                 args = args[1:]
 
             for arg in args:
@@ -387,6 +396,9 @@ class FunctionsMixin(TranslatorBase):
                         receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}{gen_str}) "
                     else:
                         receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}) "
+            elif dec_info.is_classmethod:
+                # Class methods are static in V (no receiver)
+                receiver_str = ""
 
             args = args[1:]  # Remove self/cls from arguments list
         elif is_unittest_method and args and args[0].arg == "self":
@@ -740,7 +752,7 @@ class FunctionsMixin(TranslatorBase):
         # Handle classmethod: map 'cls' to struct name in scope
         if dec_info.is_classmethod and orig_args and orig_args[0].arg == "cls":
             # Map 'cls' to the struct name within the function body
-            self.name_remap[orig_args[0].arg] = struct_name
+            self.name_remap[orig_args[0].arg] = self._get_full_self_type(struct_name)
             current_scope.add(orig_args[0].arg)
 
         self._scope_stack.append(current_scope)
@@ -892,23 +904,27 @@ class FunctionsMixin(TranslatorBase):
                 args = node.args.args
                 if hasattr(node.args, "posonlyargs"):
                     args = node.args.posonlyargs + args
-                if args and args[0].arg == "self":
-                    # For overloads, we use the method name (node.name) or ov_key to decide mutability.
-                    # If any overload implementation needs mutability, we should probably emit it.
-                    # Heuristic: constructors (new/init) always need mut, setters need mut.
-                    # General methods: check analyzer's mutability map.
-                    is_mutated = False
-                    if hasattr(self, 'type_inference') and hasattr(self.type_inference, 'mutability_map'):
-                         mut_info = self.type_inference.mutability_map.get("self")
-                         if mut_info:
-                             is_mutated = mut_info.get("is_mutated", False)
+                if args and (args[0].arg == "self" or args[0].arg == "cls"):
+                    if args[0].arg == "self":
+                        # For overloads, we use the method name (node.name) or ov_key to decide mutability.
+                        # If any overload implementation needs mutability, we should probably emit it.
+                        # Heuristic: constructors (new/init) always need mut, setters need mut.
+                        # General methods: check analyzer's mutability map.
+                        is_mutated = False
+                        if hasattr(self, 'type_inference') and hasattr(self.type_inference, 'mutability_map'):
+                             mut_info = self.type_inference.mutability_map.get("self")
+                             if mut_info:
+                                 is_mutated = mut_info.get("is_mutated", False)
 
-                    mut_receiver = "mut " if getattr(dec_info, 'is_setter', False) or is_init or node.name == "__init__" or is_mutated else ""
-                    if self.current_class_generics:
-                        gen_str = f"[{', '.join(self.current_class_generics)}]"
-                        receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}{gen_str}) "
+                        mut_receiver = "mut " if getattr(dec_info, 'is_setter', False) or is_init or node.name == "__init__" or is_mutated else ""
+                        if self.current_class_generics:
+                            gen_str = f"[{', '.join(self.current_class_generics)}]"
+                            receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}{gen_str}) "
+                        else:
+                            receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}) "
                     else:
-                        receiver_str = f"({mut_receiver}{args[0].arg} {struct_name}) "
+                        # 'cls' is handled as static, no receiver_str
+                        pass
 
             # Generate mangled name based on argument types
             type_suffix_parts = []
@@ -938,17 +954,19 @@ class FunctionsMixin(TranslatorBase):
 
             if is_init or is_new_factory:
                 base_func_name = self._get_factory_name(struct_name)
-                ret_type = struct_name
-                if self.current_class_generics:
-                    gen_str = f"[{', '.join(self.current_class_generics)}]"
-                    ret_type += gen_str
+                ret_type = self._get_full_self_type(struct_name)
                 if is_pydantic:
                     ret_type = "!" + ret_type
             else:
                 base_func_name = self._sanitize_name(node.name)
+
+                # Static/Class methods naming for overloads: Prefix with struct name
+                if (dec_info.is_static or dec_info.is_classmethod):
+                    base_func_name = f"{struct_name}_{base_func_name}"
+
                 if node.name == "__init__":
                     base_func_name = "init"
-                elif self.current_class:
+                elif self.current_class and not (dec_info.is_static or dec_info.is_classmethod):
                     base_func_name = self._sanitize_name(
                         self._mangle_name(base_func_name, self.current_class)
                     )
@@ -1014,6 +1032,19 @@ class FunctionsMixin(TranslatorBase):
                 else:
                     self.output.append(f"{self._indent()}mut self := {ret_type}{{}}")
 
+            # Handle classmethod for overloads: map 'cls' in scope
+            is_cls_method = False
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Name) and decorator.id == "classmethod":
+                    is_cls_method = True
+                    break
+                if isinstance(decorator, ast.Attribute) and decorator.attr == "classmethod":
+                    is_cls_method = True
+                    break
+
+            if is_cls_method:
+                self.name_remap["cls"] = self._get_full_self_type(struct_name)
+
             try:
                 # Note: We are using the implementation body, but its local types might need casts
                 # However, the V compiler handles explicit interfaces or generic returns if valid.
@@ -1037,6 +1068,8 @@ class FunctionsMixin(TranslatorBase):
                 for stmt in body:
                     self.visit(stmt)
             finally:
+                if is_cls_method:
+                    del self.name_remap["cls"]
                 self.current_function_return_type = prev_ret_type
                 if is_init:
                     class_info = self.defined_classes.get(struct_name, {})

--- a/py2v_transpiler/tests/translator/test_classmethods.py
+++ b/py2v_transpiler/tests/translator/test_classmethods.py
@@ -1,0 +1,73 @@
+import ast
+import pytest
+from py2v_transpiler.core.parser import PyASTParser
+from py2v_transpiler.core.translator import VNodeVisitor
+from py2v_transpiler.core.analyzer import TypeInference
+
+def test_classmethod_on_generic_class():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+from typing import Generic, TypeVar, Any
+
+T = TypeVar('T')
+
+class UserDict(Generic[T]):
+    @classmethod
+    def fromkeys(cls, iterable: Any, value: Any = None) -> 'UserDict[T]':
+        \"\"\"Create new instance from iterable.\"\"\"
+        return cls()
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    # Current issues expected:
+    # 1. 'cls int' in signature
+    # 2. wrong generic name in function decl if it was generic (fromkeys[T])
+    # 3. wrong return type
+
+    # Expected V Output (Ideal):
+    # fn UserDict_fromkeys[T](iterable Any, value Any) UserDict[T] {
+    #    // Create new instance from iterable.
+    #    return UserDict[T]{}
+    # }
+
+    print(result)
+
+    assert "fn UserDict_fromkeys[T](iterable Any, value Any) UserDict[T] {" in result
+    assert "cls int" not in result
+    assert "return UserDict[T]{}" in result
+
+def test_overloaded_classmethod_on_generic_class():
+    parser = PyASTParser()
+    analyzer = TypeInference()
+    translator = VNodeVisitor(analyzer)
+
+    code = """
+from typing import Generic, TypeVar, Any, Iterable, overload
+
+T = TypeVar('T')
+
+class UserDict(Generic[T]):
+    @overload
+    @classmethod
+    def fromkeys(cls, iterable: Iterable[T]) -> 'UserDict[T]': ...
+
+    @classmethod
+    def fromkeys(cls, iterable: Any, value: Any = None) -> 'UserDict[T]':
+        return cls()
+"""
+    tree = parser.parse(code)
+    analyzer.analyze(tree)
+    result = translator.visit_Module(tree)
+
+    print(result)
+
+    # Check that cls is NOT in the overloaded variant signature
+    # Signature of fromkeys_iterable_T should NOT have cls
+    assert "fn UserDict_fromkeys_arr_generic[T](cls int" not in result
+    assert "fn UserDict_fromkeys_arr_generic[T](" in result
+    assert "UserDict[T]{}" in result # return UserDict[T]() -> return UserDict[T]{}


### PR DESCRIPTION
The transpiler previously generated invalid V code for `@classmethod` on generic classes, including an explicit `cls int` parameter and incorrect generic naming. This PR fixes these issues by stripping `cls` from signatures, applying snake_case class-prefixed naming (required by V), and remapping `cls` to the full generic type within the function body. It also ensures generic classes are correctly looked up during instantiation calls by stripping generic arguments before searching the defined classes map.

Fixes #341

---
*PR created automatically by Jules for task [6590981074517633221](https://jules.google.com/task/6590981074517633221) started by @yaskhan*