### PR TITLE
Handle future imports in SemanticAnalyzer

### DIFF
--- a/vlangtr/mypy/nativeparse.v
+++ b/vlangtr/mypy/nativeparse.v
@@ -1197,7 +1197,9 @@ fn (mut b ASTReadBuffer) read_type_param() TypeParam {
 }
 
 fn (mut b ASTReadBuffer) read_mypy_file() MypyFile {
-	mut node := MypyFile{}
+	mut node := MypyFile{
+		future_imports: map[string]bool{}
+	}
 	b.read_loc(mut node.base)
 	node.defs = b.read_list_stmt()
 	node.path = b.read_str()

--- a/vlangtr/mypy/nodes.v
+++ b/vlangtr/mypy/nodes.v
@@ -1830,6 +1830,7 @@ pub mut:
 	is_bom                  bool
 	plugin_deps             map[string]bool
 	ignored_lines           []int
+	future_imports          map[string]bool
 }
 
 pub fn (f &MypyFile) is_package_init_file() bool {

--- a/vlangtr/mypy/parse.v
+++ b/vlangtr/mypy/parse.v
@@ -47,6 +47,7 @@ fn empty_tree(fnam string, mod_name ?string) MypyFile {
 		is_stub:                 fnam.ends_with('.pyi')
 		is_partial_stub_package: false
 		plugin_deps:             map[string]bool{}
+		future_imports:          map[string]bool{}
 	}
 }
 

--- a/vlangtr/mypy/semanal.v
+++ b/vlangtr/mypy/semanal.v
@@ -1238,7 +1238,12 @@ fn (sa SemanticAnalyzer) correct_relative_import(node ImportFrom) string {
 
 // set_future_import_flags sets future import flags
 fn (mut sa SemanticAnalyzer) set_future_import_flags(fullname string) {
-	// TODO: handle future imports if field is added to MypyFile
+	if fullname in future_imports {
+		if mut mod := sa.cur_mod_node {
+			feature := future_imports[fullname]
+			mod.future_imports[feature] = true
+		}
+	}
 }
 
 // push_type_args adds type args

--- a/vlangtr/mypy/treetransform.v
+++ b/vlangtr/mypy/treetransform.v
@@ -96,6 +96,7 @@ pub fn (mut t TransformVisitor) visit_mypy_file(mut node MypyFile) !AnyNode {
 		defs:          t.statements(mut node.defs)
 		is_bom:        node.is_bom
 		ignored_lines: ignored_lines
+		future_imports: node.future_imports.clone()
 	}
 	new.fullname = node.fullname
 	new.path = node.path


### PR DESCRIPTION
Implemented handling of `__future__` imports in the native V SemanticAnalyzer. This involved adding a new field to the `MypyFile` struct to track these imports and implementing the `set_future_import_flags` method in `SemanticAnalyzer` to populate this field during analysis. Initialization and cloning logic for the new field was also added to ensure consistency across the AST.

---
*PR created automatically by Jules for task [14026884538784285892](https://jules.google.com/task/14026884538784285892) started by @yaskhan*